### PR TITLE
Implement OAuth2 Login flow

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -202,56 +202,27 @@
    limitations under the License.
 
 
-================================================================================
+===============================================================================
 
-For the `bootstrap.py` file:
+For the methods noted in the `croud/util.py` and
+`tests/unit_tests/test_util.py` files:
 
-Buildout <http://www.buildout.org/>
+Copyright (c) Microsoft Corporation. All rights reserved.
 
-Copyright (c) 2006 Zope Foundation and Contributors.
-All Rights Reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-Zope Public License (ZPL) Version 2.1
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-A copyright notice accompanies this license document that identifies the
-copyright holders.
-
-This license has been certified as open source. It has also been designated as
-GPL compatible by the Free Software Foundation (FSF).
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions in source code must retain the accompanying copyright
-notice, this list of conditions, and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the accompanying copyright
-notice, this list of conditions, and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-
-3. Names of the copyright holders must not be used to endorse or promote
-products derived from this software without prior written permission from the
-copyright holders.
-
-4. The right to distribute this software or to use it for any purpose does not
-give you the right to use Servicemarks (sm) or Trademarks (tm) of the
-copyright
-holders. Use of them is covered by separate agreement with the copyright
-holders.
-
-5. If any files are modified, you must cause the modified files to carry
-prominent notices stating that you changed the files and the date of any
-change.
-
-Disclaimer
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY EXPRESSED
-OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
-EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
-EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.rst
+++ b/README.rst
@@ -28,15 +28,6 @@ Run it::
 
     croud -h
 
-Environment Variables
----------------------
-
-:``CLOUD_SESSION``: The session-cookie that is used to authenticate a user
-                    against CrateDB Cloud. As long as the OAuth2 mechanism in
-                    ``CROUD`` is not in place this needs to be set to simulate
-                    the login. Copy the value of the cookie ``session`` from
-                    the browser that has been used for OAuth on CrateDB cloud.
-
 
 Testing
 -------

--- a/croud/config.py
+++ b/croud/config.py
@@ -17,37 +17,28 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
-import argh
+import os
+from pathlib import Path
 
-from croud.config import Configuration
-from croud.gql import run_query
-from croud.printer import print_format
+from appdirs import user_config_dir
 
 
-@argh.arg(
-    "-r",
-    "--region",
-    choices=["westeurope.azure", "eastus.azure", "bregenz.a1"],
-    default="bregenz.a1",
-    type=str,
-)
-@argh.arg("--env", choices=["dev", "prod"], default="prod", type=str)
-@argh.arg("-o", "--output-fmt", choices=["json"], default="json", type=str)
-def me(region=None, env=None, output_fmt=None) -> None:
-    """
-    Prints the current logged in user
-    """
-    # Todo: Return the current logged in user
-    query = """
-{
-  me {
-    email
-    username
-    name
-  }
-}
-    """
+class Configuration:
 
-    token = Configuration.read_token()
-    resp = run_query(query, region, env, token)
-    print_format(resp["me"], output_fmt)
+    USER_CONFIG_DIR: Path = Path(user_config_dir("Crate"))
+    CONFIG_FILE_NAME: str = "cloud_token"
+    CONFIG_PATH: Path = USER_CONFIG_DIR / CONFIG_FILE_NAME
+
+    @staticmethod
+    def write_token(token: str) -> None:
+        os.makedirs(os.path.dirname(Configuration.CONFIG_PATH), exist_ok=True)
+        with open(Configuration.CONFIG_PATH, "w") as f:
+            f.write(token)
+
+    @staticmethod
+    def read_token() -> str:
+        if Configuration.CONFIG_PATH.exists():
+            with open(Configuration.CONFIG_PATH) as f:
+                return f.readline()
+        else:
+            return ""

--- a/croud/login.py
+++ b/croud/login.py
@@ -17,10 +17,44 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+import asyncio
 
-def login() -> None:
+import argh
+
+from croud.printer import print_error, print_info
+from croud.server import Server
+from croud.util import can_launch_browser, open_page_in_browser
+
+
+@argh.arg("--env", choices=["dev", "prod"], default="prod", type=str)
+def login(env=None) -> None:
     """
     Performs an OAuth2 Login to CrateDB Cloud
     """
+    if can_launch_browser():
+        loop = asyncio.get_event_loop()
+        server = Server(loop)
+        server.create_web_app()
+        loop.run_until_complete(server.start())
 
-    pass
+        domain = "cratedb.cloud"
+        if env.lower() == "dev":
+            domain = "cratedb-dev.cloud"
+
+        login_url = f"https://bregenz.a1.{domain}/oauth2/login?cli=true"
+        open_page_in_browser(login_url)
+        print_info("A browser tab has been launched for you to login.")
+
+        try:
+            loop.run_forever()
+        except KeyboardInterrupt:
+            loop.run_until_complete(server.stop())
+            exit(1)
+        finally:
+            loop.run_until_complete(server.stop())
+        loop.close()
+    else:
+        print_error("Login only works with a valid browser installed.")
+        exit(1)
+
+    print_info("Login successful.")

--- a/croud/printer.py
+++ b/croud/printer.py
@@ -33,6 +33,10 @@ def print_error(text: str):
     print(Fore.RED + "==> Error: " + Style.RESET_ALL + text)
 
 
+def print_info(text: str):
+    print(Fore.CYAN + "==> Info: " + Style.RESET_ALL + text)
+
+
 class FormatPrinter:
     def __init__(self):
         self.supported_formats: dict = {"json": self._json}

--- a/croud/server.py
+++ b/croud/server.py
@@ -1,0 +1,67 @@
+# Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+import asyncio
+
+from aiohttp import web
+
+from croud.config import Configuration
+
+
+class Server:
+    LOGIN_MSG: str = """
+    <b>You have successfully logged into CrateDB Cloud!</b>
+    <p>This windows can be closed.</p>"""
+
+    PORT: int = 8400
+
+    def __init__(self, loop: asyncio.AbstractEventLoop):
+        self.loop = loop
+
+    def create_web_app(self) -> web.Application:
+        app = web.Application()
+        app.add_routes([web.get("/", self.handle_session)])
+        app.on_response_prepare.append(self.after_request)  # type: ignore
+        self.runner = web.AppRunner(app)
+        return app
+
+    def handle_session(self, req: web.Request) -> web.Response:
+        """Token handler that receives the session token from query param"""
+        try:
+            Configuration.write_token(req.rel_url.query["token"])
+        except KeyError as ex:
+            return web.Response(status=500, text=f"No query param {ex!s} in request")
+        return web.Response(status=200, text=Server.LOGIN_MSG, content_type="text/html")
+
+    async def after_request(self, req: web.Request, resp: web.Response) -> web.Response:
+        """middleware callback right after a request got handled"""
+        # stop the event loop right after successful login response
+        # so that the Server can be terminated gracefully afterwards
+        self.loop.stop()
+        return resp
+
+    async def start(self) -> None:
+        """Start a local HTTP server"""
+        await self.runner.setup()
+        site = web.TCPSite(self.runner, "localhost", Server.PORT)
+        await site.start()
+
+    async def stop(self) -> None:
+        """Shutdown the server gracefully"""
+        await self.runner.cleanup()

--- a/croud/util.py
+++ b/croud/util.py
@@ -1,0 +1,78 @@
+# Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+import os
+import platform
+import subprocess
+import webbrowser
+from typing import Tuple
+
+
+# This function was copied from the <https://github.com/Azure/azure-cli>
+# project. See `LICENSE` for more information.
+def can_launch_browser() -> bool:
+    platform_name, release = get_platform_info()
+    if is_wsl(platform_name, release) or platform_name != "linux":
+        return True
+    gui_env_vars = ["DESKTOP_SESSION", "XDG_CURRENT_DESKTOP", "DISPLAY"]
+    result = True
+    if platform_name == "linux":
+        if any(os.getenv(v) for v in gui_env_vars):
+            try:
+                default_browser = webbrowser.get()
+                if (
+                    getattr(default_browser, "name", None) == "www-browser"
+                ):  # text browser won't work
+                    result = False
+            except webbrowser.Error:
+                result = False
+        else:
+            result = False
+
+    return result
+
+
+# This function was copied from the <https://github.com/Azure/azure-cli>
+# project. See `LICENSE` for more information.
+def is_wsl(platform_name: str, release: str) -> bool:
+    platform_name, release = get_platform_info()
+    return platform_name == "linux" and release.split("-")[-1] == "microsoft"
+
+
+# This function was copied from the <https://github.com/Azure/azure-cli>
+# project. See `LICENSE` for more information.
+def get_platform_info() -> Tuple[str, str]:
+    uname = platform.uname()
+    platform_name = getattr(uname, "system", None) or uname[0]
+    release = getattr(uname, "release", None) or uname[2]
+    return platform_name.lower(), release.lower()
+
+
+# This function was copied from the <https://github.com/Azure/azure-cli>
+# project. See `LICENSE` for more information.
+def open_page_in_browser(url: str) -> int:
+    platform_name, release = get_platform_info()
+    if is_wsl(platform_name, release):  # windows 10 linux subsystem
+        try:
+            return subprocess.call(
+                ["cmd.exe", "/c", "start {}".format(url.replace("&", "^&"))]
+            )
+        except FileNotFoundError:  # WSL might be too old
+            pass
+    return webbrowser.open_new_tab(url)

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     long_description=readme,
     entry_points={"console_scripts": ["croud = croud.__main__:main"]},
     packages=["croud"],
-    install_requires=["argh", "requests", "colorama"],
+    install_requires=["argh", "aiohttp", "requests", "colorama", "appdirs"],
     extras_require={
         "testing": [
             "pytest>=3,<4",
@@ -46,10 +46,11 @@ setup(
             "pytest-isort",
             "pytest-black",
             "pytest-mypy",
+            "pytest-aiohttp",
             "mypy",
-            "black==18.6b4",
+            "black",
         ],
-        "development": ["black==18.6b4"],
+        "development": ["black"],
     },
     python_requires=">=3.6",
     classifiers=[

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -1,0 +1,50 @@
+# Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+import unittest
+from unittest import mock
+
+from croud.config import Configuration
+
+
+class TestConfiguration(unittest.TestCase):
+    def test_write_token(self):
+        m = mock.mock_open()
+        with mock.patch("croud.config.open", m, create=True):
+            Configuration.write_token("eyJraWQiOiIxZTlnZGs3IiwiYWxnIjoiUlMyNTYifQ")
+
+        m.assert_called_once_with(Configuration.CONFIG_PATH, "w")
+        handle = m()
+        handle.write.assert_called_once_with(
+            "eyJraWQiOiIxZTlnZGs3IiwiYWxnIjoiUlMyNTYifQ"
+        )
+
+    @mock.patch("pathlib.Path.exists", return_value=True)
+    def test_read_token_exists(self, mock_path_exists):
+        m = mock.mock_open(read_data="eyJraWQiOiIxZTlnZGs3IiwiYWxnIjoiUlMyNTYifQ")
+        with mock.patch("croud.config.open", m, create=True):
+            token = Configuration.read_token()
+
+        m.assert_called_once_with(Configuration.CONFIG_PATH)
+        self.assertEqual(token, "eyJraWQiOiIxZTlnZGs3IiwiYWxnIjoiUlMyNTYifQ")
+
+    @mock.patch("pathlib.Path.exists", return_value=False)
+    def test_read_token_not_exists(self, mock_path_exists):
+        token = Configuration.read_token()
+        self.assertEqual(token, "")

--- a/tests/unit_tests/test_server.py
+++ b/tests/unit_tests/test_server.py
@@ -1,0 +1,64 @@
+# Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+
+from unittest import mock
+
+from aiohttp.test_utils import TestClient, TestServer, loop_context
+
+from croud.config import Configuration
+from croud.server import Server
+
+
+class TestLocalServer(object):
+    @mock.patch.object(Configuration, "write_token")
+    def test_token_handler_and_login(self, mock_write_token):
+        with loop_context() as loop:
+            server = Server(loop)
+            app = server.create_web_app()
+            client = TestClient(TestServer(app), loop=loop)
+            loop.run_until_complete(client.start_server())
+
+            async def test_get_route():
+                with mock.patch.object(loop, "stop"):
+                    resp = await client.get("?token=123")
+                    assert resp.status == 200
+                    text = await resp.text()
+                    assert "You have successfully logged into CrateDB Cloud!" in text
+
+            loop.run_until_complete(test_get_route())
+            loop.run_until_complete(client.close())
+
+    @mock.patch.object(Configuration, "write_token")
+    def test_token_missing_for_login(self, mock_write_token):
+        with loop_context() as loop:
+            server = Server(loop)
+            app = server.create_web_app()
+            client = TestClient(TestServer(app), loop=loop)
+            loop.run_until_complete(client.start_server())
+
+            async def test_get_route():
+                with mock.patch.object(loop, "stop"):
+                    resp = await client.get("/")
+                    assert resp.status == 500
+                    text = await resp.text()
+                    assert "No query param 'token' in request" in text
+
+            loop.run_until_complete(test_get_route())
+            loop.run_until_complete(client.close())

--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -1,0 +1,88 @@
+# Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+import unittest
+from unittest import mock
+
+from croud.util import (
+    can_launch_browser,
+    get_platform_info,
+    is_wsl,
+    open_page_in_browser,
+)
+
+
+class TestUtils(unittest.TestCase):
+
+    # This function was copied from the <https://github.com/Azure/azure-cli>
+    # project. See `LICENSE` for more information.
+    @mock.patch("webbrowser.open", autospec=True)
+    @mock.patch("subprocess.call", autospec=True)
+    def test_open_page_in_browser(self, subprocess_call_mock, webbrowser_open_mock):
+        platform_name, release = get_platform_info()
+        open_page_in_browser("http://foo")
+        if is_wsl(platform_name, release):
+            subprocess_call_mock.assert_called_once_with(
+                ["cmd.exe", "/c", "start http://foo"]
+            )
+        else:
+            webbrowser_open_mock.assert_called_once_with("http://foo", 2)
+
+    # This function was copied from the <https://github.com/Azure/azure-cli>
+    # project. See `LICENSE` for more information.
+    @mock.patch("croud.util.get_platform_info", autospec=True)
+    @mock.patch("webbrowser.get", autospec=True)
+    def test_can_launch_browser(self, webbrowser_get_mock, get_platform_mock):
+        # WSL is always fine
+        get_platform_mock.return_value = ("linux", "4.4.0-17134-microsoft")
+        result = can_launch_browser()
+        self.assertTrue(result)
+
+        # windows is always fine
+        get_platform_mock.return_value = ("windows", "10")
+        result = can_launch_browser()
+        self.assertTrue(result)
+
+        # osx is always fine
+        get_platform_mock.return_value = ("darwin", "10")
+        result = can_launch_browser()
+        self.assertTrue(result)
+
+        # now tests linux
+        with mock.patch("os.environ", autospec=True) as env_mock:
+            # when no GUI, return false
+            get_platform_mock.return_value = ("linux", "4.15.0-1014-azure")
+            env_mock.get.return_value = None
+            result = can_launch_browser()
+            self.assertFalse(result)
+
+            # when there is gui, and browser is a good one, return True
+            browser_mock = mock.MagicMock()
+            browser_mock.name = "goodone"
+            env_mock.get.return_value = "foo"
+            result = can_launch_browser()
+            self.assertTrue(result)
+
+            # when there is gui, but the browser is text mode, return False
+            browser_mock = mock.MagicMock()
+            browser_mock.name = "www-browser"
+            webbrowser_get_mock.return_value = browser_mock
+            env_mock.get.return_value = "foo"
+            result = can_launch_browser()
+            self.assertFalse(result)


### PR DESCRIPTION
This adds CrateDB Cloud Login functionality to the subcommand `login`.
It will open a browser tab to start the authentication process using OAuth.
After successful authentication the session token gets stored in the
local app dir (OS platform specific) so that other commands (e.g. `me`) can
can use it to run a query.

```bash
(env) ☁  ~  croud login --env dev
==> Info: A browser tab has been launched for you to login.
==> Info: Login successful.
(env) ☁  ~  croud me -r eastus.azure --env dev
{
  "email": "hoschi@crate.io",
  "username": "Google_104209952803880732135",
  "name": "Hoschi Galoschi"
}
```