### PR TITLE
Fix SSL error: SSL certificate verify failed

### DIFF
--- a/croud/session.py
+++ b/croud/session.py
@@ -17,9 +17,11 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+import ssl
 from types import TracebackType
 from typing import Dict, Optional, Type
 
+import certifi
 from aiohttp import ClientSession, ContentTypeError, TCPConnector  # type: ignore
 
 from croud.config import Configuration
@@ -48,6 +50,11 @@ class HttpSession:
         self.url = url
 
         token = Configuration.read_token()
+
+        if conn is None:
+            ssl_context = ssl.create_default_context(cafile=certifi.where())
+            conn = TCPConnector(ssl_context=ssl_context)
+
         self.client = ClientSession(
             cookies={"session": token}, connector=conn, headers=headers
         )

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     long_description=readme,
     entry_points={"console_scripts": ["croud = croud.__main__:main"]},
     packages=["croud"],
-    install_requires=["argh", "aiohttp", "colorama", "appdirs"],
+    install_requires=["argh", "aiohttp", "colorama", "appdirs", "certifi"],
     extras_require={
         "testing": [
             "pytest>=3,<4",


### PR DESCRIPTION
This popped up because Python 3.6 on MacOSX comes with its own private copy of
OpenSSL 👎 . That means the trust certificates in the system are no longer used as
defaults by the Python ssl module.

To fix this it is necessary to to ship the `Certifi` lib that contains
a collection of root certificates of the Mozilla CA Bundle.