### PR TITLE
Removed name field from gql query in me sub command

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changes for croud
 Unreleased
 ==========
 
+- Removed name field from `me` subcommand
+
 0.1.0 - 2018/11/28
 ==================
 

--- a/croud/me.py
+++ b/croud/me.py
@@ -46,7 +46,6 @@ def me(region=None, output_fmt=None, env=None) -> None:
     me {
         email
         username
-        name
     }
 }
     """


### PR DESCRIPTION
It was decided that for the time being the CLI should not return the name field of a user, as it may be empty; so I've removed it from the GraphQL query