### PR TITLE
Note the incompatible storage format of config across versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,12 @@ Use the command ``croud -h`` to list all available subcommands or
 
     $ croud [subcommand] {parameters}
 
+.. note::
+
+    ``Croud`` stores the login credentials inside ``<UserDataDir>/Crate/croud.yaml``.
+    The storage format across versions < 1.x is incompatible. This means that it
+    might be necessary to remove the config after an upgrade.
+
 
 Contributing
 ============

--- a/croud/logout.py
+++ b/croud/logout.py
@@ -30,12 +30,15 @@ def logout(args: Namespace) -> None:
         Configuration.override_context(args.env)
 
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(make_request())
+    env = Configuration.get_env()
+    token = Configuration.get_token()
 
+    loop.run_until_complete(make_request(env, token))
     Configuration.set_token("")
+
     print_info("You have been logged out.")
 
 
-async def make_request() -> None:
-    async with HttpSession() as session:
+async def make_request(env: str, token: str) -> None:
+    async with HttpSession(env, token) as session:
         await session.logout()

--- a/croud/me.py
+++ b/croud/me.py
@@ -43,12 +43,16 @@ def me(args: Namespace) -> None:
     if args.env is not None:
         Configuration.override_context(args.env)
 
-    async def fetch_data(region: str) -> JsonDict:
-        async with HttpSession(region) as session:
+    env = Configuration.get_env()
+    token = Configuration.get_token()
+    region = args.region
+
+    async def fetch_data() -> JsonDict:
+        async with HttpSession(env, token, region) as session:
             return await session.fetch(query)
 
     loop = asyncio.get_event_loop()
-    rows = loop.run_until_complete(fetch_data(args.region))
+    rows = loop.run_until_complete(fetch_data())
 
     if rows:
         if isinstance(rows, dict):

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         "pyyaml",
         "certifi",
         "tabulate",
+        "schema",
     ],
     extras_require={
         "testing": [

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -20,12 +20,18 @@
 import unittest
 from unittest import mock
 
-from croud.config import load_config, write_config
+from croud.config import (
+    Configuration,
+    IncompatibleConfigException,
+    load_config,
+    write_config,
+)
 
 
 class TestConfiguration(unittest.TestCase):
+    @mock.patch.object(Configuration, "validate", return_value={})
     @mock.patch("yaml.load")
-    def test_load_config(self, mock_yaml_load):
+    def test_load_config(self, mock_yaml_load, mock_validate):
         m = mock.mock_open()
         with mock.patch("croud.config.open", m, create=True):
             load_config()
@@ -42,3 +48,10 @@ class TestConfiguration(unittest.TestCase):
         mock_yaml_dump.assert_called_once_with(
             config, m(), default_flow_style=False, allow_unicode=True
         )
+
+    def test_incompatible_schema(self):
+        config = {"incompatible": "", "schema": ""}
+        with self.assertRaises(IncompatibleConfigException) as cm:
+            Configuration.validate(config)
+
+        self.assertTrue("Incompatible storage format" in str(cm.exception))

--- a/tests/unit_tests/test_session.py
+++ b/tests/unit_tests/test_session.py
@@ -47,13 +47,20 @@ me_response = {
 
 
 class TestHttpSession(unittest.TestCase):
+    @mock.patch.object(Configuration, "get_env", return_value="dev")
     @mock.patch.object(Configuration, "get_token", return_value="eyJraWQiOiIx")
-    def test_query_success(self, mock_token):
+    def test_query_success(self, mock_token, mock_env):
         with loop_context() as loop:
 
             async def test_query():
+                env = Configuration.get_env()
+                token = Configuration.get_token()
                 async with HttpSession(
-                    url="https://cratedb.local/graphql", conn=connector, headers=headers
+                    env,
+                    token,
+                    url="https://cratedb.local/graphql",
+                    conn=connector,
+                    headers=headers,
                 ) as session:
                     result = await session.fetch(me_query)
                     self.assertEqual(result, me_response)
@@ -68,14 +75,19 @@ class TestHttpSession(unittest.TestCase):
             loop.run_until_complete(test_query())
             loop.run_until_complete(fake_cloud.stop())
 
+    @mock.patch.object(Configuration, "get_env", return_value="dev")
     @mock.patch.object(Configuration, "get_token", return_value="")
     @mock.patch("croud.session.print_error")
-    def test_query_unauthorized(self, mock_print_error, mock_token):
+    def test_query_unauthorized(self, mock_print_error, mock_token, mock_env):
         with loop_context() as loop:
 
             async def test_query():
+                env = Configuration.get_env()
+                token = Configuration.get_token()
                 with self.assertRaises(SystemExit) as cm:
                     async with HttpSession(
+                        env,
+                        token,
                         url="https://cratedb.local/graphql",
                         conn=connector,
                         headers=headers,


### PR DESCRIPTION
If the config file that holds the login credentials has an
incompatible or incorrect format the user will be informed to remove the
config file.

```
==> Error: Incompatible storage format in /home/mibe/.config/Crate/croud.yaml. Please remove the config and try again.
```