### PR TITLE
Fixed --help and --version argument on top level

### DIFF
--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -86,7 +86,8 @@ def main():
             },
         },
     }
-    CMD(commands)
+    croud_cmd = CMD()
+    croud_cmd.create_parent_cmd(1, commands)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fixes an issue that caused the `--version` argument to show a help
output instead of a version tag.