### PR TITLE
Removed hardware specs from list clusters command

### DIFF
--- a/croud/clusters/list.py
+++ b/croud/clusters/list.py
@@ -34,7 +34,6 @@ def clusters_list(args: Namespace) -> None:
             id
             name
             numNodes
-            hardwareSpecs
             crateVersion
             projectId
             username

--- a/tests/unit_tests/test_commands.py
+++ b/tests/unit_tests/test_commands.py
@@ -92,7 +92,6 @@ class TestClustersList(unittest.TestCase):
             id
             name
             numNodes
-            hardwareSpecs
             crateVersion
             projectId
             username
@@ -118,7 +117,6 @@ class TestClustersList(unittest.TestCase):
             id
             name
             numNodes
-            hardwareSpecs
             crateVersion
             projectId
             username


### PR DESCRIPTION
It's been decided that the hardware specs should not be included in the output when listing clusters