### PR TITLE
Fix: Login page needs to be picked according to the env set in current_context.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changes for croud
 Unreleased
 ==========
 
+- Fix: Login page needs to be picked according to the env set in current_context.
+
 - Removed `env` subcommand (replaced with `config set --env [prod|env]`)
 
 - Added subcommand `config get` that prints out a specified default config setting

--- a/croud/login.py
+++ b/croud/login.py
@@ -31,21 +31,14 @@ def login(args: Namespace) -> None:
     Performs an OAuth2 Login to CrateDB Cloud
     """
 
-    env = "prod" if args.env is None else args.env
-
     if can_launch_browser():
-        Configuration.override_context(env)
         loop = asyncio.get_event_loop()
         server = Server(loop)
         server.create_web_app()
         loop.run_until_complete(server.start())
 
-        domain = "cratedb.cloud"
-        if env.lower() == "dev":
-            domain = "cratedb-dev.cloud"
-
-        login_url = f"https://bregenz.a1.{domain}/oauth2/login?cli=true"
-        open_page_in_browser(login_url)
+        env = _set_login_env(args.env)
+        open_page_in_browser(_login_url(env))
         print_info("A browser tab has been launched for you to login.")
 
         try:
@@ -63,3 +56,16 @@ def login(args: Namespace) -> None:
         exit(1)
 
     print_info("Login successful.")
+
+
+def _set_login_env(env: str) -> str:
+    env = Configuration.get_env() if env is None else env
+    Configuration.override_context(env)
+    return env
+
+
+def _login_url(env: str) -> str:
+    domain = "cratedb.cloud"
+    if env.lower() == "dev":
+        domain = "cratedb-dev.cloud"
+    return f"https://bregenz.a1.{domain}/oauth2/login?cli=true"

--- a/tests/unit_tests/test_commands.py
+++ b/tests/unit_tests/test_commands.py
@@ -23,7 +23,7 @@ from unittest import mock
 
 from croud.clusters.list import clusters_list
 from croud.config import Configuration, config_get, config_set
-from croud.login import login
+from croud.login import _login_url, _set_login_env, login
 from croud.logout import logout
 from croud.server import Server
 
@@ -52,7 +52,7 @@ class TestLogin(unittest.TestCase):
     ):
         m = mock.mock_open()
         with mock.patch("croud.config.open", m, create=True):
-            login(Namespace(env="dev"))
+            login(Namespace(env=None))
 
         calls = [
             mock.call("A browser tab has been launched for you to login."),
@@ -60,16 +60,45 @@ class TestLogin(unittest.TestCase):
         ]
         mock_print_info.assert_has_calls(calls)
 
+    @mock.patch("croud.config.Configuration.get_env", return_value="dev")
     @mock.patch("croud.login.can_launch_browser", return_value=False)
     @mock.patch("croud.login.print_error")
-    def test_login_no_valid_browser(self, mock_print_error, mock_can_launch_browser):
+    def test_login_no_valid_browser(
+        self, mock_print_error, mock_can_launch_browser, mock_get_env
+    ):
         with self.assertRaises(SystemExit) as cm:
-            login(Namespace(env="dev"))
+            login(Namespace(env=None))
 
         mock_print_error.assert_called_once_with(
             "Login only works with a valid browser installed."
         )
         self.assertEqual(cm.exception.code, 1)
+
+    @mock.patch("croud.config.Configuration.override_context")
+    @mock.patch("croud.config.Configuration.get_env", return_value="dev")
+    def test_login_env_from_current_context(self, mock_get_env, mock_override_context):
+        env = _set_login_env(None)
+        self.assertEqual(env, "dev")
+
+    def test_login_env_override_context_from_argument(self):
+        env = _set_login_env("prod")
+        self.assertEqual(env, "prod")
+
+    def test_login_urls_from_valid_envs(self):
+        url = _login_url("dev")
+        self.assertEqual(
+            "https://bregenz.a1.cratedb-dev.cloud/oauth2/login?cli=true", url
+        )
+
+        url = _login_url("prod")
+        self.assertEqual("https://bregenz.a1.cratedb.cloud/oauth2/login?cli=true", url)
+
+        url = _login_url("PROD")
+        self.assertEqual("https://bregenz.a1.cratedb.cloud/oauth2/login?cli=true", url)
+
+    def test_env_fallback_url(self):
+        url = _login_url("invalid")
+        self.assertEqual("https://bregenz.a1.cratedb.cloud/oauth2/login?cli=true", url)
 
 
 class TestLogout(unittest.TestCase):


### PR DESCRIPTION
This fixes a problem that occurred if `current_context: dev` the login has been opened on a prod environment instead of dev.