### PR TITLE
[SECURITY] Prevent arbitrary code execution when loading config file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for croud
 Unreleased
 ==========
 
+- SECURITY: prevented arbitrary code execution when loading the config file
+  (ref. `CVE-2017-18342 <https://nvd.nist.gov/vuln/detail/CVE-2017-18342>`_)
+
 - Fix: Login page needs to be picked according to the env set in current_context.
 
 - Removed `env` subcommand (replaced with `config set --env [prod|env]`)

--- a/croud/config.py
+++ b/croud/config.py
@@ -130,7 +130,7 @@ def create_default_config() -> None:
 
 def load_config() -> dict:
     with open(Configuration.FILEPATH, "r") as f:
-        config = yaml.load(f)
+        config = yaml.safe_load(f)
 
     try:
         return Configuration.validate(config)


### PR DESCRIPTION
PyYAML's `load()` does not guard against code execution. Let's use
`safe_load()`.

Ref https://nvd.nist.gov/vuln/detail/CVE-2017-18342