### PR TITLE
Added fixed choices for plan-type arg and removed region arg from me command

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changes for croud
 Unreleased
 ==========
 
+- Removed region arg from `me` command
+
 - Added `organizations create` sub command that creates an organization (super users only)
 
 0.3.0 - 2018/01/09

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -47,7 +47,7 @@ def main():
     commands: dict = {
         "me": {
             "description": "Prints the current logged in user",
-            "extra_args": [output_fmt_arg, region_arg],
+            "extra_args": [output_fmt_arg],
             "calls": me,
         },
         "login": {

--- a/croud/cmd.py
+++ b/croud/cmd.py
@@ -150,7 +150,11 @@ def org_name_arg(parser: ArgumentParser) -> None:
 
 def org_plan_type_arg(parser: ArgumentParser) -> None:
     parser.add_argument(
-        "--plan-type", type=int, help="Plan type for organization", required=True
+        "--plan-type",
+        choices=[1, 2, 3, 4, 5, 6],
+        type=int,
+        help="Plan type for organization",
+        required=True,
     )
 
 


### PR DESCRIPTION
This just makes sure that when creating an organization only a valid plan type can be selected. I also removed the region arg from the `me` command because it doesn't do anything