### PR TITLE
Fixed config get output-fmt by formatting arg name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changes for croud
 Unreleased
 ==========
 
+- Fixed `config get output-fmt` command
+
 - Added `organizations list` sub command that lists organizations
 
 - Removed region arg from `me` command

--- a/croud/config.py
+++ b/croud/config.py
@@ -83,6 +83,7 @@ class Configuration:
 
     @staticmethod
     def get_setting(setting: str) -> str:
+        setting = setting.replace("-", "_")
         if setting == "env":
             return Configuration.get_env()
         return load_config()[setting]


### PR DESCRIPTION
Running ``croud config get output-fmt`` was returning an error because the key in settings uses an underscore, not a hyphen. This PR replaces hyphens with underscores before attempting to read settings