### PR TITLE
Implemented projects create command

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changes for croud
 Unreleased
 ==========
 
+- Added ``projects create`` command that allows organization admins and
+  super users to create new projects. Super users are able to create projects
+  in all organizations, organization admins only in the organization that
+  the user is part of.
+
 - Added `users list` sub command that lists all users within organizations
   that a user is part of. For super users it will list all users from all
   organizations. Super users can also filter by organization ID, and list

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -32,6 +32,7 @@ from croud.cmd import (
     org_plan_type_arg,
     output_fmt_arg,
     project_id_arg,
+    project_name_arg,
     region_arg,
     resource_id_arg,
     role_fqn_arg,
@@ -43,6 +44,7 @@ from croud.logout import logout
 from croud.me import me
 from croud.organizations.create import organizations_create
 from croud.organizations.list import organizations_list
+from croud.projects.create import project_create
 from croud.projects.list import projects_list
 from croud.users.list import users_list
 from croud.users.roles.add import roles_add
@@ -80,12 +82,23 @@ def main():
         "projects": {
             "help": "Manage CrateDB Cloud projects.",
             "sub_commands": {
+                "create": {
+                    "help": "Create a project in the organization the user belongs to.",
+                    "extra_args": [
+                        output_fmt_arg,
+                        project_name_arg,
+                        lambda req_opt_group, opt_opt_group: org_id_arg(
+                            req_opt_group, opt_opt_group, True
+                        ),
+                    ],
+                    "calls": project_create,
+                },
                 "list": {
                     "help": "Lists all projects for the current "
                     "user in the specified region.",
                     "extra_args": [output_fmt_arg, region_arg],
                     "calls": projects_list,
-                }
+                },
             },
         },
         "clusters": {
@@ -119,7 +132,13 @@ def main():
                 "list": {
                     "help": "List all users within organizations that the "
                     "logged in user is part of.",
-                    "extra_args": [output_fmt_arg, org_id_arg, no_org_arg],
+                    "extra_args": [
+                        output_fmt_arg,
+                        lambda req_opt_group, opt_opt_group: org_id_arg(
+                            req_opt_group, opt_opt_group, False
+                        ),
+                        no_org_arg,
+                    ],
                     "calls": users_list,
                 },
                 "roles": {

--- a/croud/cmd.py
+++ b/croud/cmd.py
@@ -207,6 +207,7 @@ def region_arg(req_args: _ArgumentGroup, opt_args: _ArgumentGroup) -> None:
         choices=["westeurope.azure", "eastus.azure", "eastus2.azure", "bregenz.a1"],
         type=str,
         help="Switch region that command will be run on.",
+        required=False,
     )
 
 
@@ -228,8 +229,11 @@ def output_fmt_arg(req_args: _ArgumentGroup, opt_args: _ArgumentGroup) -> None:
     )
 
 
-def org_id_arg(req_args: _ArgumentGroup, opt_args: _ArgumentGroup) -> None:
-    opt_args.add_argument("--org-id", type=str, help="Organization ID.")
+def org_id_arg(
+    req_args: _ArgumentGroup, opt_args: _ArgumentGroup, required: bool
+) -> None:
+    group = req_args if required else opt_args
+    group.add_argument("--org-id", type=str, help="Organization ID.", required=required)
 
 
 def no_org_arg(req_args: _ArgumentGroup, opt_args: _ArgumentGroup) -> None:

--- a/croud/projects/create.py
+++ b/croud/projects/create.py
@@ -1,0 +1,43 @@
+# Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+from argparse import Namespace
+
+from croud.gql import Query, print_query
+
+
+def project_create(args: Namespace) -> None:
+    """
+    Creates a project in the organization the user belongs to.
+    """
+
+    _query = f"""
+        mutation {{
+            createProject(input: {{
+                name: "{args.name}",
+                organizationId: "{args.org_id}"
+            }}) {{
+                id
+            }}
+        }}
+    """
+
+    query = Query(_query, args)
+    query.execute()
+    print_query(query, "createProject")

--- a/docs/docs/commands.txt
+++ b/docs/docs/commands.txt
@@ -269,7 +269,7 @@ This output format looks like this:
 ``projects``
 ============
 
-The ``project`` command allows you to create, modify and view project
+The ``projects`` command allows you to create, modify and view project
 resources.
 
 You must specify a subcommand, like so:
@@ -277,6 +277,36 @@ You must specify a subcommand, like so:
 .. code-block:: console
 
     sh$ croud projects [SUBCOMMAND] [OPTIONS]
+
+.. projects.create:
+
+``create``
+----------
+
+The ``create`` subcommand creates a new project in the given organization.
+The user has to be admin of the organization to perform this operation.
+
+.. code-block:: console
+
+    sh$ croud projects create [OPTIONS]
+
+Recognized options:
+
++---------------------------+----------+----------------------------+
+| Option                    | Required | Description                |
++===========================+==========+============================+
+| ``--name <STRING>``       | Yes      | The desired project name.  |
++---------------------------+----------+----------------------------+
+| ``--org-id <STRING>``     | Yes      | Creates the project in the |
+|                           |          | in the chosen organization.|
++---------------------------+----------+----------------------------+
+| ``--output-fmt <STRING>`` | No       | The desired output format. |
+|                           |          |                            |
+|                           |          | One of:                    |
+|                           |          |                            |
+|                           |          | - ``json``                 |
+|                           |          | - ``table``                |
++---------------------------+----------+----------------------------+
 
 .. projects.list:
 

--- a/tests/unit_tests/test_commands.py
+++ b/tests/unit_tests/test_commands.py
@@ -29,6 +29,8 @@ from croud.login import _login_url, _set_login_env, login
 from croud.logout import logout
 from croud.organizations.create import organizations_create
 from croud.organizations.list import organizations_list
+from croud.projects.create import project_create
+from croud.projects.list import projects_list
 from croud.server import Server
 from croud.users.list import users_list
 from croud.users.roles.add import roles_add
@@ -266,6 +268,48 @@ mutation {
         args = Namespace(env="dev")
         with mock.patch("croud.organizations.list.print_query") as mock_print:
             organizations_list(args)
+            assert_query(mock_print, query)
+
+
+@mock.patch("croud.config.load_config", return_value=Configuration.DEFAULT_CONFIG)
+@mock.patch.object(Query, "execute")
+class TestProjects:
+    def test_create(self, mock_execute, mock_load_config):
+        mutation = """
+        mutation {
+            createProject(input: {
+                name: "new-project",
+                organizationId: "organization-id"
+            }) {
+                id
+            }
+        }
+    """
+
+        args = Namespace(
+            env="dev", name="new-project", org_id="organization-id", output_fmt="json"
+        )
+        with mock.patch("croud.projects.create.print_query") as mock_print:
+            project_create(args)
+            assert_query(mock_print, mutation)
+
+    def test_list_projects_org_admin(self, mock_execute, mock_load_config):
+        query = """
+{
+    allProjects {
+        data {
+            id
+            name
+            region
+            organizationId
+        }
+    }
+}
+    """
+
+        args = Namespace(env="dev")
+        with mock.patch("croud.projects.list.print_query") as mock_print:
+            projects_list(args)
             assert_query(mock_print, query)
 
 


### PR DESCRIPTION
Implemented the `croud projects create` command with the arguments:
* name (required)
* organizationId (required)

+ implemented test for the `croud projects list` command