### PR TITLE
Added users list sub command

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changes for croud
 Unreleased
 ==========
 
+- Added `users list` sub command that lists all users within organizations
+  that a user is part of. For super users it will list all users from all
+  organizations. Super users can also filter by organization ID, and list
+  all users who are not part of any organization.
+
 - Required/Optional arguments are shown separated in help
 
 - Added eastus2 to available regions.

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -26,6 +26,8 @@ import colorama
 from croud.clusters.list import clusters_list
 from croud.cmd import (
     CMD,
+    no_org_arg,
+    org_id_arg,
     org_name_arg,
     org_plan_type_arg,
     output_fmt_arg,
@@ -42,6 +44,7 @@ from croud.me import me
 from croud.organizations.create import organizations_create
 from croud.organizations.list import organizations_list
 from croud.projects.list import projects_list
+from croud.users.list import users_list
 from croud.users.roles.add import roles_add
 from croud.users.roles.list import roles_list
 from croud.users.roles.remove import roles_remove
@@ -113,6 +116,12 @@ def main():
         "users": {
             "help": "Manage CrateDB Cloud users.",
             "sub_commands": {
+                "list": {
+                    "help": "List all users within organizations that the "
+                    "logged in user is part of.",
+                    "extra_args": [output_fmt_arg, org_id_arg, no_org_arg],
+                    "calls": users_list,
+                },
                 "roles": {
                     "help": "Manage CrateDB Cloud user roles.",
                     "sub_commands": {
@@ -150,7 +159,7 @@ def main():
                             "calls": roles_list,
                         },
                     },
-                }
+                },
             },
         },
     }

--- a/croud/cmd.py
+++ b/croud/cmd.py
@@ -228,6 +228,21 @@ def output_fmt_arg(req_args: _ArgumentGroup, opt_args: _ArgumentGroup) -> None:
     )
 
 
+def org_id_arg(req_args: _ArgumentGroup, opt_args: _ArgumentGroup) -> None:
+    opt_args.add_argument("--org-id", type=str, help="Organization ID.")
+
+
+def no_org_arg(req_args: _ArgumentGroup, opt_args: _ArgumentGroup) -> None:
+    opt_args.add_argument(
+        "--no-org",
+        nargs="?",
+        default=False,
+        const=True,
+        type=bool,
+        help="Only show users that are not part of any organization.",
+    )
+
+
 def org_name_arg(req_args: _ArgumentGroup, opt_args: _ArgumentGroup) -> None:
     req_args.add_argument("--name", type=str, help="Organization Name.", required=True)
 

--- a/croud/users/list.py
+++ b/croud/users/list.py
@@ -1,0 +1,51 @@
+# Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+from argparse import Namespace
+
+from croud.util import get_entity_list
+
+
+def users_list(args: Namespace) -> None:
+    """
+    List all users within organizations that the logged in user is part of
+    """
+
+    query = """
+{
+    allUsers {
+        data {
+            uid
+            email
+            username
+        }
+    }
+}
+"""
+
+    queryArgs = ""
+    if args.no_org:
+        queryArgs = "(queryArgs: {noOrg: true})"
+    if args.org_id:
+        queryArgs = f'(queryArgs: {{organizationId: "{args.org_id}"}})'
+
+    if queryArgs is not "":
+        query = query.replace("allUsers", f"allUsers{queryArgs}")
+
+    get_entity_list(query, args, "allUsers")

--- a/docs/docs/commands.txt
+++ b/docs/docs/commands.txt
@@ -420,6 +420,42 @@ You must specify a subcommand, like so:
 
     sh$ croud users [SUBCOMMAND] [OPTIONS]
 
+.. users.list:
+
+``list``
+--------
+
+The ``list`` subcommand allows you to list all users within organizations
+that you are part of:
+
+.. code-block:: console
+
+    sh$ croud users list [OPTIONS]
+
+Recognized options:
+
++---------------------------+----------+----------------------------+
+| Option                    | Required | Description                |
++===========================+==========+============================+
+| ``--org-id <STRING>``     | No       | Filter by users in a       |
+|                           |          | specific organization. This|
+|                           |          | option is only available   |
+|                           |          | to super users.            |
++---------------------------+----------+----------------------------+
+| ``--no-org <BOOL>``       | No       | Filter by users who are not|
+|                           |          | part of any organization.  |
+|                           |          | This option is only        |
+|                           |          | available to super users.  |
++---------------------------+----------+----------------------------+
+| ``--output-fmt <STRING>`` | No       | The desired output format. |
+|                           |          |                            |
+|                           |          | One of:                    |
+|                           |          |                            |
+|                           |          | - ``json``                 |
+|                           |          | - ``table``                |
++---------------------------+----------+----------------------------+
+
+
 .. users.roles:
 
 ``roles``

--- a/tests/unit_tests/test_commands.py
+++ b/tests/unit_tests/test_commands.py
@@ -28,6 +28,7 @@ from croud.logout import logout
 from croud.organizations.create import organizations_create
 from croud.organizations.list import organizations_list
 from croud.server import Server
+from croud.users.list import users_list
 from croud.users.roles.add import roles_add
 from croud.users.roles.list import roles_list
 from croud.users.roles.remove import roles_remove
@@ -398,3 +399,83 @@ mutation {{
         )
         roles_remove(args)
         mock_print_format.assert_called_once_with(self.authd_response, "json")
+
+
+class TestUsersList(unittest.TestCase):
+    @mock.patch("croud.users.list.get_entity_list")
+    def test_users_list_no_filter(self, mock_get_entity_list):
+        query = """
+{
+    allUsers {
+        data {
+            uid
+            email
+            username
+        }
+    }
+}
+"""
+
+        args: Namespace = Namespace(
+            env=None, no_org=False, org_id=None, output_fmt=None
+        )
+        users_list(args)
+        mock_get_entity_list.assert_called_once_with(query, args, "allUsers")
+
+    @mock.patch("croud.users.list.get_entity_list")
+    def test_users_list_org_filter(self, mock_get_entity_list):
+        query = """
+{
+    allUsers(queryArgs: {organizationId: "abc"}) {
+        data {
+            uid
+            email
+            username
+        }
+    }
+}
+"""
+
+        args: Namespace = Namespace(
+            env=None, no_org=False, org_id="abc", output_fmt=None
+        )
+        users_list(args)
+        mock_get_entity_list.assert_called_once_with(query, args, "allUsers")
+
+    @mock.patch("croud.users.list.get_entity_list")
+    def test_users_list_no_org_filter(self, mock_get_entity_list):
+        query = """
+{
+    allUsers(queryArgs: {noOrg: true}) {
+        data {
+            uid
+            email
+            username
+        }
+    }
+}
+"""
+
+        args: Namespace = Namespace(env=None, no_org=True, org_id=None, output_fmt=None)
+        users_list(args)
+        mock_get_entity_list.assert_called_once_with(query, args, "allUsers")
+
+    @mock.patch("croud.users.list.get_entity_list")
+    def test_users_list_filter_dont_conflict(self, mock_get_entity_list):
+        query = """
+{
+    allUsers(queryArgs: {organizationId: "abc"}) {
+        data {
+            uid
+            email
+            username
+        }
+    }
+}
+"""
+
+        args: Namespace = Namespace(
+            env=None, no_org=True, org_id="abc", output_fmt=None
+        )
+        users_list(args)
+        mock_get_entity_list.assert_called_once_with(query, args, "allUsers")


### PR DESCRIPTION
This adds the ``croud users list`` sub command, that allows users to list all users within organizations that they are part of. Super users are able to filter these by organization ID (``--org-id``), or list all users who are not part of any organization (``--no-org``)