### PR TITLE
fix broken query testing

### DIFF
--- a/croud/clusters/list.py
+++ b/croud/clusters/list.py
@@ -19,7 +19,7 @@
 
 from argparse import Namespace
 
-from croud.gql import Query
+from croud.gql import Query, print_query
 
 
 def clusters_list(args: Namespace) -> None:
@@ -49,4 +49,5 @@ def clusters_list(args: Namespace) -> None:
         _query = _query.replace("allClusters", query_filter)
 
     query = Query(_query, args)
-    query.print_result("allClusters")
+    query.execute()
+    print_query(query, "allClusters")

--- a/croud/me.py
+++ b/croud/me.py
@@ -19,7 +19,7 @@
 
 from argparse import Namespace
 
-from croud.gql import Query
+from croud.gql import Query, print_query
 
 
 def me(args: Namespace) -> None:
@@ -37,4 +37,5 @@ def me(args: Namespace) -> None:
     """
 
     query = Query(_query, args)
-    query.print_result("me")
+    query.execute()
+    print_query(query, "me")

--- a/croud/organizations/create.py
+++ b/croud/organizations/create.py
@@ -19,7 +19,7 @@
 
 from argparse import Namespace
 
-from croud.gql import Query
+from croud.gql import Query, print_query
 
 
 def organizations_create(args: Namespace) -> None:
@@ -44,4 +44,5 @@ mutation {
     _query = _query.replace("PLAN_TYPE", f"{args.plan_type}")
 
     query = Query(_query, args)
-    query.print_result("createOrganization")
+    query.execute()
+    print_query(query, "createOrganization")

--- a/croud/organizations/list.py
+++ b/croud/organizations/list.py
@@ -19,7 +19,7 @@
 
 from argparse import Namespace
 
-from croud.gql import Query
+from croud.gql import Query, print_query
 
 
 def organizations_list(args: Namespace) -> None:
@@ -46,4 +46,5 @@ def organizations_list(args: Namespace) -> None:
 """
 
     query = Query(_query, args)
-    query.print_result("allOrganizations")
+    query.execute()
+    print_query(query, "allOrganizations")

--- a/croud/projects/list.py
+++ b/croud/projects/list.py
@@ -19,7 +19,7 @@
 
 from argparse import Namespace
 
-from croud.gql import Query
+from croud.gql import Query, print_query
 
 
 def projects_list(args: Namespace) -> None:
@@ -41,4 +41,5 @@ def projects_list(args: Namespace) -> None:
     """
 
     query = Query(_query, args)
-    query.print_result("allProjects")
+    query.execute()
+    print_query(query, "allProjects")

--- a/croud/users/list.py
+++ b/croud/users/list.py
@@ -19,7 +19,7 @@
 
 from argparse import Namespace
 
-from croud.gql import Query
+from croud.gql import Query, print_query
 
 
 def users_list(args: Namespace) -> None:
@@ -49,4 +49,5 @@ def users_list(args: Namespace) -> None:
         _query = _query.replace("allUsers", f"allUsers{queryArgs}")
 
     query = Query(_query, args)
-    query.print_result("allUsers")
+    query.execute()
+    print_query(query, "allUsers")

--- a/croud/users/roles/add.py
+++ b/croud/users/roles/add.py
@@ -19,7 +19,7 @@
 
 from argparse import Namespace
 
-from croud.gql import Query
+from croud.gql import Query, print_query
 
 
 def roles_add(args: Namespace) -> None:
@@ -45,4 +45,5 @@ mutation {
     mutation = mutation.replace("resid", args.resource)
 
     query = Query(mutation, args)
-    query.print_result("addRoleToUser")
+    query.execute()
+    print_query(query, "addRoleToUser")

--- a/croud/users/roles/list.py
+++ b/croud/users/roles/list.py
@@ -19,7 +19,7 @@
 
 from argparse import Namespace
 
-from croud.gql import Query
+from croud.gql import Query, print_query
 
 
 def roles_list(args: Namespace) -> None:
@@ -39,4 +39,5 @@ def roles_list(args: Namespace) -> None:
 """
 
     query = Query(_query, args)
-    query.print_result("allRoles")
+    query.execute()
+    print_query(query, "allRoles")

--- a/croud/users/roles/remove.py
+++ b/croud/users/roles/remove.py
@@ -19,7 +19,7 @@
 
 from argparse import Namespace
 
-from croud.gql import Query
+from croud.gql import Query, print_query
 
 
 def roles_remove(args: Namespace) -> None:
@@ -40,4 +40,5 @@ mutation {
     mutation = mutation.replace("resid", args.resource, 1)
 
     query = Query(mutation, args)
-    query.print_result("removeRoleFromUser")
+    query.execute()
+    print_query(query, "removeRoleFromUser")

--- a/tox.ini
+++ b/tox.ini
@@ -7,4 +7,4 @@ commands = pytest {posargs}
 setenv = LANG=en_US.UTF-8
 
 [pytest]
-addopts = --doctest-modules --doctest-glob='*.rst' --flake8 --black --mypy --isort --ignore=docs
+addopts = --doctest-modules --doctest-glob='**/*.rst' --flake8 --black --mypy --isort --ignore=docs


### PR DESCRIPTION
During the initialisation of some tests in tests/unit_tests/test_commands.py (Tests which were mocking "Query") were raising exception. These tests were still passing because pytest just ignored the exceptions.
To resolve this we needed a function where the function call is in our hands, and for that we split the function call of print_result into two: one function for executing and one function for printing, meaning we can directly get access to the result.
