### PR TITLE
Added the region arg back to creating projects

### DIFF
--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -90,6 +90,7 @@ def main():
                         lambda req_opt_group, opt_opt_group: org_id_arg(
                             req_opt_group, opt_opt_group, True
                         ),
+                        region_arg,
                     ],
                     "calls": project_create,
                 },


### PR DESCRIPTION
This adds the region argument back to ``projects create``. The reason for this is that Croud should provide the option to create a project in any region. If no ``--region`` option is provided, Croud will send the request to your default region (configured with ``config set --region REGION``). The mutation itself does not need a region input parameter because it will determine the project region via meta data (basically the subdomain (`<region>.cratedb[-dev].cloud`)). However, in Croud you should be able to override your default region, like you can when listing projects: ``croud projects list`` will list all projects in your default region, but this can be override so that you can check what your projects you have in other regions without changing your default region with ``config set --region``; like so: ``croud projects list --region eastus.azure``. Creating projects should function in the same way.