### PR TITLE
Added organizations users add and remove commands

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,16 @@ Changes for croud
 Unreleased
 ==========
 
+- Added ``organizations users remove`` command that allows organization
+  admins to remove users from organizations that they are admins for, by
+  specifying an organization ID, and a user email address or ID. Super
+  users can remove users from any organization.
+
+- Added ``organizations users add`` command that allows organization admins
+  to add new users to organizations they are admins for, by specifying
+  an organization ID, and a user email address or ID. Super users can
+  add users to any organization.
+
 - Update to `crate-docs-theme <https://github.com/crate/crate-docs-theme>`_
   0.5.70.
 

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -166,7 +166,15 @@ def main():
                     "sub_commands": {
                         "add": {
                             "help": "Add user to organization",
-                            "extra_args": [user_id_or_email_arg, role_fqn_arg],
+                            "extra_args": [
+                                user_id_or_email_arg,
+                                lambda req_opt_group, opt_opt_group: role_fqn_arg(
+                                    req_opt_group, opt_opt_group, False
+                                ),
+                                lambda req_opt_group, opt_opt_group: org_id_arg(
+                                    req_opt_group, opt_opt_group, False
+                                ),
+                            ],
                             "calls": org_users_add,
                         },
                         "remove": {
@@ -174,7 +182,10 @@ def main():
                             "extra_args": [
                                 lambda req_opt_group, opt_opt_group: user_id_arg(
                                     req_opt_group, opt_opt_group, True
-                                )
+                                ),
+                                lambda req_opt_group, opt_opt_group: org_id_arg(
+                                    req_opt_group, opt_opt_group, False
+                                ),
                             ],
                             "calls": org_users_remove,
                         },
@@ -210,7 +221,9 @@ def main():
                                     req_opt_group, opt_opt_group, True
                                 ),
                                 output_fmt_arg,
-                                role_fqn_arg,
+                                lambda req_opt_group, opt_opt_group: role_fqn_arg(
+                                    req_opt_group, opt_opt_group, True
+                                ),
                             ],
                             "calls": roles_add,
                         },
@@ -224,7 +237,9 @@ def main():
                                     req_opt_group, opt_opt_group, True
                                 ),
                                 output_fmt_arg,
-                                role_fqn_arg,
+                                lambda req_opt_group, opt_opt_group: role_fqn_arg(
+                                    req_opt_group, opt_opt_group, True
+                                ),
                             ],
                             "calls": roles_remove,
                         },

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -49,12 +49,14 @@ from croud.cmd import (
     resource_id_arg,
     role_fqn_arg,
     user_id_arg,
+    user_id_or_email_arg,
 )
 from croud.config import Configuration, config_get, config_set
 from croud.login import login
 from croud.logout import logout
 from croud.me import me
 from croud.organizations.commands import organizations_create, organizations_list
+from croud.organizations.users.commands import org_users_add, org_users_remove
 from croud.products.deploy import product_deploy
 from croud.projects.commands import project_create, projects_list
 from croud.users.commands import users_list
@@ -158,6 +160,25 @@ def main():
                     "help": "List all organizations for the logged in user.",
                     "extra_args": [output_fmt_arg],
                     "calls": organizations_list,
+                },
+                "users": {
+                    "help": "Add/remove users to/from organizations.",
+                    "sub_commands": {
+                        "add": {
+                            "help": "Add user to organization",
+                            "extra_args": [user_id_or_email_arg, role_fqn_arg],
+                            "calls": org_users_add,
+                        },
+                        "remove": {
+                            "help": "Remove user from organization",
+                            "extra_args": [
+                                lambda req_opt_group, opt_opt_group: user_id_arg(
+                                    req_opt_group, opt_opt_group, True
+                                )
+                            ],
+                            "calls": org_users_remove,
+                        },
+                    },
                 },
             },
         },

--- a/croud/cmd.py
+++ b/croud/cmd.py
@@ -284,6 +284,12 @@ def user_id_arg(
     group.add_argument("--user", type=str, help="User ID.", required=required)
 
 
+def user_id_or_email_arg(req_args: _ArgumentGroup, opt_args: _ArgumentGroup) -> None:
+    req_args.add_argument(
+        "--user", type=str, help="User email address or ID", required=True
+    )
+
+
 def product_tier_arg(req_args: _ArgumentGroup, opt_args: _ArgumentGroup) -> None:
     req_args.add_argument("--tier", type=str, help="Product Tier.", required=True)
 

--- a/croud/cmd.py
+++ b/croud/cmd.py
@@ -268,12 +268,15 @@ def resource_id_arg(
     group.add_argument("--resource", type=str, help="Resource ID.", required=required)
 
 
-def role_fqn_arg(req_args: _ArgumentGroup, opt_args: _ArgumentGroup) -> None:
-    req_args.add_argument(
+def role_fqn_arg(
+    req_args: _ArgumentGroup, opt_args: _ArgumentGroup, required: bool
+) -> None:
+    group = req_args if required else opt_args
+    group.add_argument(
         "--role",
         type=str,
         help="Role FQN. Run `croud roles list` for a list of available roles.",
-        required=True,
+        required=required,
     )
 
 

--- a/croud/organizations/users/commands.py
+++ b/croud/organizations/users/commands.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+#
+# Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+
+from argparse import Namespace
+
+from croud.gql import Query, print_query
+
+
+def org_users_add(args: Namespace):
+    qargs = f'{{user: "{args.user}", role_fqn: "{args.role}"}}'
+    mutation = f"""
+    mutation {{
+        addUserToOrganization(input: {qargs}) {{
+            user: {{
+                uid
+                email
+                organizationId
+            }}
+        }}
+    }}
+    """
+
+    query = Query(mutation, args)
+    query.execute()
+    print_query(query, "addUserToOrganization")
+
+
+def org_users_remove(args: Namespace):
+    mutation = f"""
+    mutation {{
+        removeUserFromOrganization(input: {{uid: "{args.user}"}}) {{
+            success
+        }}
+    }}
+    """
+
+    query = Query(mutation, args)
+    query.execute()
+    print_query(query, "removeUserFromOrganization")

--- a/croud/organizations/users/commands.py
+++ b/croud/organizations/users/commands.py
@@ -26,10 +26,15 @@ from croud.gql import Query, print_query
 
 
 def org_users_add(args: Namespace):
-    qargs = f'{{user: "{args.user}", role_fqn: "{args.role}"}}'
+    qargs = f'user: "{args.user}"'
+    if hasattr(args, "role"):
+        qargs += f', role_fqn: "{args.role}"'
+    if hasattr(args, "org_id"):
+        qargs += f', organizationId: "{args.org_id}"'
+
     mutation = f"""
     mutation {{
-        addUserToOrganization(input: {qargs}) {{
+        addUserToOrganization(input: {{{qargs}}}) {{
             user: {{
                 uid
                 email
@@ -45,9 +50,13 @@ def org_users_add(args: Namespace):
 
 
 def org_users_remove(args: Namespace):
+    qargs = f'uid: "{args.user}"'
+    if hasattr(args, "org_id"):
+        qargs += f', organizationId: "{args.org_id}"'
+
     mutation = f"""
     mutation {{
-        removeUserFromOrganization(input: {{uid: "{args.user}"}}) {{
+        removeUserFromOrganization(input: {{{qargs}}}) {{
             success
         }}
     }}

--- a/docs/docs/commands.txt
+++ b/docs/docs/commands.txt
@@ -264,6 +264,72 @@ This output format looks like this:
        ...
    ]
 
+.. organizations.users:
+
+``users``
+---------
+
+The ``users`` subcommand allows you to add and remove users from an organization.
+
+You must specify a second subcommand, like so:
+
+.. code-block:: console
+
+    sh$ croud organizations users [SUBCOMMAND] [OPTIONS]
+
+.. NOTE::
+
+    These subcommands are only available to organization admins and superusers.
+
+.. organizations.roles.add:
+
+``add``
+~~~~~~~
+
+The ``add`` subcommand adds a new user to an organization.
+
+.. code-block:: console
+
+    sh$ croud organizations users add [OPTIONS]
+
+Available options:
+
++---------------------------+----------+----------------------------+
+| Option                    | Required | Description                |
++===========================+==========+============================+
+| ``--org-id <STRING>``     | Yes      | The ID of the organization |
+|                           |          | you wish to add a user to. |
++---------------------------+----------+----------------------------+
+| ``--user <STRING>``       | Yes      | The email address or ID of |
+|                           |          | the user you wish to add to|
+|                           |          | the organization.          |
++---------------------------+----------+----------------------------+
+
+.. organizations.roles.remove:
+
+``remove``
+~~~~~~~~~~
+
+The ``remove`` subcommand removes a user from an organization.
+
+.. code-block:: console
+
+    sh$ croud organizations users remove [OPTIONS]
+
+Available options:
+
++---------------------------+----------+----------------------------+
+| Option                    | Required | Description                |
++===========================+==========+============================+
+| ``--org-id <STRING>``     | Yes      | The ID of the organization |
+|                           |          | you wish to remove a user  |
+|                           |          | from.                      |
++---------------------------+----------+----------------------------+
+| ``--user <STRING>``       | Yes      | The email address or ID of |
+|                           |          | the user you wish to remove|
+|                           |          | from the organization.     |
++---------------------------+----------+----------------------------+
+
 .. _products:
 
 ``products``

--- a/docs/docs/commands.txt
+++ b/docs/docs/commands.txt
@@ -297,12 +297,15 @@ Available options:
 +---------------------------+----------+----------------------------+
 | Option                    | Required | Description                |
 +===========================+==========+============================+
-| ``--org-id <STRING>``     | Yes      | The ID of the organization |
-|                           |          | you wish to add a user to. |
-+---------------------------+----------+----------------------------+
 | ``--user <STRING>``       | Yes      | The email address or ID of |
 |                           |          | the user you wish to add to|
 |                           |          | the organization.          |
++---------------------------+----------+----------------------------+
+| ``--role <STRING>``       | No       | The role FQN of the role   |
+|                           |          | you wish to give the user. |
++---------------------------+----------+----------------------------+
+| ``--org-id <STRING>``     | No       | The ID of the organization |
+|                           |          | you wish to add a user to. |
 +---------------------------+----------+----------------------------+
 
 .. organizations.roles.remove:
@@ -321,13 +324,12 @@ Available options:
 +---------------------------+----------+----------------------------+
 | Option                    | Required | Description                |
 +===========================+==========+============================+
-| ``--org-id <STRING>``     | Yes      | The ID of the organization |
-|                           |          | you wish to remove a user  |
-|                           |          | from.                      |
-+---------------------------+----------+----------------------------+
 | ``--user <STRING>``       | Yes      | The email address or ID of |
 |                           |          | the user you wish to remove|
 |                           |          | from the organization.     |
++---------------------------+----------+----------------------------+
+| ``--org-id <STRING>``     | No       | The ID of the organization |
+|                           |          | you wish to add a user to. |
 +---------------------------+----------+----------------------------+
 
 .. _products:

--- a/tests/unit_tests/test_commands.py
+++ b/tests/unit_tests/test_commands.py
@@ -271,6 +271,24 @@ class TestOrganizations:
     def test_add_user(self, mock_execute, mock_load_config):
         query = """
     mutation {
+        addUserToOrganization(input: {user: "1"}) {
+            user: {
+                uid
+                email
+                organizationId
+            }
+        }
+    }
+    """
+
+        args = Namespace(env="dev", user="1")
+        with mock.patch("croud.organizations.users.commands.print_query") as mock_print:
+            org_users_add(args)
+            assert_query(mock_print, query)
+
+    def test_add_user_fqn(self, mock_execute, mock_load_config):
+        query = """
+    mutation {
         addUserToOrganization(input: {user: "1", role_fqn: "org_admin"}) {
             user: {
                 uid
@@ -286,6 +304,24 @@ class TestOrganizations:
             org_users_add(args)
             assert_query(mock_print, query)
 
+    def test_add_user_org_id(self, mock_execute, mock_load_config):
+        query = """
+    mutation {
+        addUserToOrganization(input: {user: "1", organizationId: "abc"}) {
+            user: {
+                uid
+                email
+                organizationId
+            }
+        }
+    }
+    """
+
+        args = Namespace(env="dev", user="1", org_id="abc")
+        with mock.patch("croud.organizations.users.commands.print_query") as mock_print:
+            org_users_add(args)
+            assert_query(mock_print, query)
+
     def test_remove_user(self, mock_execute, mock_load_config):
         query = """
     mutation {
@@ -296,6 +332,20 @@ class TestOrganizations:
     """
 
         args = Namespace(env="dev", user="1")
+        with mock.patch("croud.organizations.users.commands.print_query") as mock_print:
+            org_users_remove(args)
+            assert_query(mock_print, query)
+
+    def test_remove_user_org_id(self, mock_execute, mock_load_config):
+        query = """
+    mutation {
+        removeUserFromOrganization(input: {uid: "1", organizationId: "abc"}) {
+            success
+        }
+    }
+    """
+
+        args = Namespace(env="dev", user="1", org_id="abc")
         with mock.patch("croud.organizations.users.commands.print_query") as mock_print:
             org_users_remove(args)
             assert_query(mock_print, query)

--- a/tests/unit_tests/test_commands.py
+++ b/tests/unit_tests/test_commands.py
@@ -28,6 +28,7 @@ from croud.gql import Query
 from croud.login import _login_url, _set_login_env, login
 from croud.logout import logout
 from croud.organizations.commands import organizations_create, organizations_list
+from croud.organizations.users.commands import org_users_add, org_users_remove
 from croud.products.deploy import product_deploy
 from croud.projects.commands import project_create, projects_list
 from croud.server import Server
@@ -265,6 +266,38 @@ class TestOrganizations:
         args = Namespace(env="dev")
         with mock.patch("croud.organizations.commands.print_query") as mock_print:
             organizations_list(args)
+            assert_query(mock_print, query)
+
+    def test_add_user(self, mock_execute, mock_load_config):
+        query = """
+    mutation {
+        addUserToOrganization(input: {user: "1", role_fqn: "org_admin"}) {
+            user: {
+                uid
+                email
+                organizationId
+            }
+        }
+    }
+    """
+
+        args = Namespace(env="dev", user="1", role="org_admin")
+        with mock.patch("croud.organizations.users.commands.print_query") as mock_print:
+            org_users_add(args)
+            assert_query(mock_print, query)
+
+    def test_remove_user(self, mock_execute, mock_load_config):
+        query = """
+    mutation {
+        removeUserFromOrganization(input: {uid: "1"}) {
+            success
+        }
+    }
+    """
+
+        args = Namespace(env="dev", user="1")
+        with mock.patch("croud.organizations.users.commands.print_query") as mock_print:
+            org_users_remove(args)
             assert_query(mock_print, query)
 
 


### PR DESCRIPTION
These two commands (``croud organiziations users add``, ``croud organizations users remove``) allow organization admins to add and remove users from organizations that they are admins for. Super users are able to add or remove any user from any organization