### PR TITLE
added graphql variables

### DIFF
--- a/croud/cmd.py
+++ b/croud/cmd.py
@@ -76,7 +76,6 @@ class CroudCliHelpFormatter(argparse.HelpFormatter):
 
 class CMD:
     def __init__(self, tree: Dict) -> None:
-        self.root_parser = self._create_root_parser()
         self.cmd_tree = tree
 
     def _create_root_parser(self) -> CroudCliArgumentParser:
@@ -112,7 +111,7 @@ class CMD:
         commands: dict,
         parent_parser: Optional[CroudCliArgumentParser] = None,
     ):
-        parser = parent_parser or self.root_parser
+        parser = parent_parser or self._create_root_parser()
         subparser = parser.add_subparsers()
 
         try:

--- a/croud/exceptions.py
+++ b/croud/exceptions.py
@@ -1,2 +1,0 @@
-class GQLError(Exception):
-    pass

--- a/croud/organizations/users/commands.py
+++ b/croud/organizations/users/commands.py
@@ -20,48 +20,45 @@
 # software solely pursuant to the terms of the relevant commercial agreement.
 
 
+import textwrap
 from argparse import Namespace
 
 from croud.gql import Query, print_query
 
 
 def org_users_add(args: Namespace):
-    qargs = f'user: "{args.user}"'
-    if hasattr(args, "role"):
-        qargs += f', role_fqn: "{args.role}"'
-    if hasattr(args, "org_id"):
-        qargs += f', organizationId: "{args.org_id}"'
-
-    mutation = f"""
-    mutation {{
-        addUserToOrganization(input: {{{qargs}}}) {{
-            user: {{
-                uid
-                email
-                organizationId
-            }}
-        }}
-    }}
+    mutation = textwrap.dedent(
+        """
+        mutation addUserToOrganization(input: UserInput!) {
+          addUserToOrganization(input: $input) {
+            user {
+              uid
+              email
+              organizationId
+            }
+          }
+        }
     """
+    ).strip()
 
+    vars = {"user": args.user, "roleFqn": args.role, "organizationId": args.org_id}
     query = Query(mutation, args)
-    query.execute()
+    query.execute(vars)
     print_query(query, "addUserToOrganization")
 
 
 def org_users_remove(args: Namespace):
-    qargs = f'uid: "{args.user}"'
-    if hasattr(args, "org_id"):
-        qargs += f', organizationId: "{args.org_id}"'
-
-    mutation = f"""
-    mutation {{
-        removeUserFromOrganization(input: {{{qargs}}}) {{
+    mutation = textwrap.dedent(
+        """
+        mutation removeUserFromOrganization(input: UserIdInput!) {
+          removeUserFromOrganization(input: $input) {
             success
-        }}
-    }}
+          }
+        }
     """
+    ).strip()
 
+    vars = {"uid": args.user, "organizationId": args.org_id}
     query = Query(mutation, args)
-    query.execute()
+    query.execute(vars)
     print_query(query, "removeUserFromOrganization")

--- a/croud/session.py
+++ b/croud/session.py
@@ -60,9 +60,13 @@ class HttpSession:
             cookies={"session": self.token}, connector=conn, headers=headers
         )
 
-    async def fetch(self, query: str, endpoint=DEFAULT_ENDPOINT) -> JsonDict:
+    async def fetch(
+        self, query: str, variables: Optional[Dict], endpoint=DEFAULT_ENDPOINT
+    ) -> JsonDict:
         url = self.url + endpoint
-        resp = await self.client.post(url, json={"query": query})
+        resp = await self.client.post(
+            url, json={"query": query, "variables": variables}
+        )
         if resp.status == 200:
             try:
                 result = await resp.json()

--- a/tests/unit_tests/test_cmd.py
+++ b/tests/unit_tests/test_cmd.py
@@ -88,17 +88,19 @@ class TestCmd:
     def test_no_args(self):
         argv = ["croud"]
         croud_cmd = CMD(self.commands)
-        with mock.patch.object(croud_cmd.root_parser, "print_help") as mock_help:
+        with mock.patch("sys.stdout.write") as stdout:
             fn, args = croud_cmd.resolve(argv)
             assert fn is None
             assert args is None
-            mock_help.assert_called_once()
+            stdout.assert_called_once()
+            assert stdout.call_args[0][0].startswith("Usage: croud") is True
 
     def test_help(self):
         argv = ["croud", "--help"]
         croud_cmd = CMD(self.commands)
-        with mock.patch.object(croud_cmd.root_parser, "print_help") as mock_help:
+        with mock.patch("sys.stdout.write") as stdout:
             with pytest.raises(SystemExit) as ex_info:
                 croud_cmd.resolve(argv)
-                mock_help.assert_called_once_with(["--help"])
+                stdout.assert_called_once()
+                assert stdout.call_args[0][0].startswith("Usage: croud") is True
         assert ex_info.value.code == 0

--- a/tests/unit_tests/test_cmd.py
+++ b/tests/unit_tests/test_cmd.py
@@ -14,11 +14,12 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
-import sys
-import unittest
 from argparse import Namespace
 from unittest import mock
 
+import pytest
+
+from croud import __version__
 from croud.cmd import CMD, region_arg
 
 
@@ -34,65 +35,70 @@ def print_region(args: Namespace):
     print(args.region)
 
 
-class TestCmd(unittest.TestCase):
-    commands: dict = {
+class TestCmd:
+    commands = {
         "say-hi": {"calls": print_hello},
         "print-env": {"calls": print_env},
         "print-region": {"extra_args": [region_arg], "calls": print_region},
         "print": {"sub_commands": {"hello": {"calls": print_hello}}},
     }
 
-    @mock.patch("builtins.print", autospec=True, side_effect=print)
-    def test_commands_registered(self, mock_print):
-        sys.argv = ["croud", "say-hi"]
-        croud_cmd = CMD()
-        croud_cmd.create_parent_cmd(1, self.commands)
+    def test_commands_registered(self):
+        argv = ["croud", "say-hi"]
+        croud_cmd = CMD(self.commands)
+        func, args = croud_cmd.resolve(argv)
 
-        mock_print.assert_called_once_with("Hello!")
+        assert func == print_hello
+        assert args == Namespace(env=None)
 
-    @mock.patch("builtins.print", autospec=True, side_effect=print)
-    def test_commands_have_env_arg(self, mock_print):
-        sys.argv = ["croud", "print-env", "--env", "dev"]
-        croud_cmd = CMD()
-        croud_cmd.create_parent_cmd(1, self.commands)
+    def test_commands_have_env_arg(self):
+        argv = ["croud", "print-env", "--env", "dev"]
+        croud_cmd = CMD(self.commands)
+        func, args = croud_cmd.resolve(argv)
 
-        mock_print.assert_called_once_with("dev")
+        assert func == print_env
+        assert args == Namespace(env="dev")
 
-    @mock.patch("builtins.print", autospec=True, side_effect=print)
-    def test_extra_args_registered(self, mock_print):
-        sys.argv = ["croud", "print-region", "--region", "westeurope.azure"]
-        croud_cmd = CMD()
-        croud_cmd.create_parent_cmd(1, self.commands)
+    def test_extra_args_registered(self):
+        argv = ["croud", "print-region", "--region", "westeurope.azure"]
+        croud_cmd = CMD(self.commands)
+        func, args = croud_cmd.resolve(argv)
 
-        mock_print.assert_called_once_with("westeurope.azure")
+        assert func == print_region
+        assert args == Namespace(env=None, region="westeurope.azure")
 
-    @mock.patch("builtins.print", autospec=True, side_effect=print)
-    def test_sub_commands_registered(self, mock_print):
-        sys.argv = ["croud", "print", "hello"]
-        croud_cmd = CMD()
-        croud_cmd.create_parent_cmd(1, self.commands)
+    def test_sub_commands_registered(self):
+        argv = ["croud", "print", "hello"]
+        croud_cmd = CMD(self.commands)
+        func, args = croud_cmd.resolve(argv)
 
-        mock_print.assert_called_once_with("Hello!")
+        assert func == print_hello
+        assert args == Namespace(env=None)
 
     def test_version(self):
-        sys.argv = ["croud", "--version"]
-        croud_cmd = CMD()
-        with mock.patch.object(croud_cmd.root_parser, "parse_args") as mock_parser:
-            croud_cmd.create_parent_cmd(1, self.commands)
-            mock_parser.assert_called_once_with(["--version"])
+        argv = ["croud", "--version"]
+        croud_cmd = CMD(self.commands)
+
+        with mock.patch("sys.stdout.write") as stdout:
+            with pytest.raises(SystemExit) as ex_info:
+                croud_cmd.resolve(argv)
+            assert ex_info.value.code == 0
+            assert stdout.call_args == mock.call("croud " + __version__ + "\n")
 
     def test_no_args(self):
-        sys.argv = ["croud"]
-        croud_cmd = CMD()
+        argv = ["croud"]
+        croud_cmd = CMD(self.commands)
         with mock.patch.object(croud_cmd.root_parser, "print_help") as mock_help:
-            croud_cmd.create_parent_cmd(1, self.commands)
+            fn, args = croud_cmd.resolve(argv)
+            assert fn is None
+            assert args is None
             mock_help.assert_called_once()
 
     def test_help(self):
-        sys.argv = ["croud", "--help"]
-        croud_cmd = CMD()
+        argv = ["croud", "--help"]
+        croud_cmd = CMD(self.commands)
         with mock.patch.object(croud_cmd.root_parser, "print_help") as mock_help:
-            with self.assertRaises(SystemExit) as cm:
-                croud_cmd.create_parent_cmd(1, self.commands)
+            with pytest.raises(SystemExit) as ex_info:
+                croud_cmd.resolve(argv)
                 mock_help.assert_called_once_with(["--help"])
-        self.assertEqual(cm.exception.code, 0)
+        assert ex_info.value.code == 0

--- a/tests/unit_tests/test_gql.py
+++ b/tests/unit_tests/test_gql.py
@@ -131,12 +131,20 @@ class PrintQueryTest:
 
 @patch("croud.config.load_config", return_value=Configuration.DEFAULT_CONFIG)
 def test_execute_query_with_variables(load_config):
-    query = Query("", Namespace(env="test"))
+    body = """
+        query {
+          me {
+            uid
+          }
+        }
+    """
     vars = {"a": "foo", "b": 42}
 
     result_future = asyncio.Future()
     result_future.set_result({"data": []})
+
+    query = Query(body, Namespace(env="test"))
     with patch.object(query, "_fetch_data", return_value=result_future) as fetch_data:
         query.execute(vars)
 
-    fetch_data.assert_called_once_with(vars)
+    fetch_data.assert_called_once_with(body, vars)


### PR DESCRIPTION
This PR adds the support for sending GraphQL requests using variables which simplifies sending input arguments for mutations.

The PR contains of 3 commits:
- https://github.com/crate/croud/pull/82/commits/a32e0770ea0e2657da2b88fc3e7db6fe030d8fa6 : enhance testability of GraphQL client
- https://github.com/crate/croud/pull/82/commits/8cecccb1e1ce307b724b5014f8f4314cff9ea015 : introduce variables for GraphQL requests
- https://github.com/crate/croud/pull/82/commits/8326c46ed3a02dbd3c353cb589f2a6317e8dc7e4 : use variables for existing mutations that require input arguments