### PR TITLE
Added local env

### DIFF
--- a/croud/cmd.py
+++ b/croud/cmd.py
@@ -195,7 +195,7 @@ def add_default_args(opt_args: _ArgumentGroup) -> None:
 def env_arg(opt_args: _ArgumentGroup) -> None:
     opt_args.add_argument(
         "--env",
-        choices=["prod", "dev"],
+        choices=["prod", "dev", "local"],
         default=None,
         type=str,
         help="Switches auth context.",

--- a/croud/config.py
+++ b/croud/config.py
@@ -38,7 +38,11 @@ class Configuration:
     DEFAULT_CONFIG: dict = {
         "auth": {
             "current_context": "prod",
-            "contexts": {"prod": {"token": ""}, "dev": {"token": ""}},
+            "contexts": {
+                "prod": {"token": ""},
+                "dev": {"token": ""},
+                "local": {"token": ""},
+            },
         },
         "region": "bregenz.a1",
         "output_fmt": "table",
@@ -57,7 +61,11 @@ class Configuration:
             {
                 "auth": {
                     "current_context": str,
-                    "contexts": {"prod": {"token": str}, "dev": {"token": str}},
+                    "contexts": {
+                        "prod": {"token": str},
+                        "dev": {"token": str},
+                        "local": {"token": str},
+                    },
                 },
                 "region": str,
                 "output_fmt": str,
@@ -100,6 +108,10 @@ class Configuration:
     def set_context(env: str) -> None:
         config = load_config()
         config["auth"]["current_context"] = env
+
+        if env == "local":
+            contexts = config["auth"]["contexts"]
+            contexts["local"]["token"] = contexts["dev"]["token"]
 
         write_config(config)
 

--- a/croud/login.py
+++ b/croud/login.py
@@ -24,7 +24,10 @@ from typing import Optional
 from croud.config import Configuration
 from croud.printer import print_error, print_info
 from croud.server import Server
+from croud.session import cloud_url
 from croud.util import can_launch_browser, open_page_in_browser
+
+LOGIN_PATH = "/oauth2/login?cli=true"
 
 
 def login(args: Namespace) -> None:
@@ -66,7 +69,4 @@ def _set_login_env(env: Optional[str]) -> str:
 
 
 def _login_url(env: str) -> str:
-    domain = "cratedb.cloud"
-    if env.lower() == "dev":
-        domain = "cratedb-dev.cloud"
-    return f"https://bregenz.a1.{domain}/oauth2/login?cli=true"
+    return cloud_url(env.lower()) + LOGIN_PATH

--- a/croud/logout.py
+++ b/croud/logout.py
@@ -22,7 +22,9 @@ from argparse import Namespace
 
 from croud.config import Configuration
 from croud.printer import print_info
-from croud.session import HttpSession
+from croud.session import HttpSession, cloud_url
+
+LOGOUT_PATH = "/oauth2/logout"
 
 
 def logout(args: Namespace) -> None:
@@ -41,4 +43,8 @@ def logout(args: Namespace) -> None:
 
 async def make_request(env: str, token: str) -> None:
     async with HttpSession(env, token) as session:
-        await session.logout()
+        await session.logout(_logout_url(env))
+
+
+def _logout_url(env: str) -> str:
+    return cloud_url(env) + LOGOUT_PATH

--- a/tests/unit_tests/test_commands.py
+++ b/tests/unit_tests/test_commands.py
@@ -28,7 +28,7 @@ from tests.unit_tests.util import CommandTestCase
 from croud.config import Configuration, config_get, config_set
 from croud.gql import Query
 from croud.login import _login_url, _set_login_env, login
-from croud.logout import logout
+from croud.logout import _logout_url, logout
 from croud.server import Server
 
 
@@ -102,6 +102,9 @@ class TestLogin:
         url = _login_url("PROD")
         assert "https://bregenz.a1.cratedb.cloud/oauth2/login?cli=true" == url
 
+        url = _login_url("local")
+        assert "http://localhost:8000/oauth2/login?cli=true" == url
+
     def test_env_fallback_url(self):
         url = _login_url("invalid")
         assert "https://bregenz.a1.cratedb.cloud/oauth2/login?cli=true" == url
@@ -121,6 +124,23 @@ class TestLogout:
 
         mock_set_token.assert_called_once_with("")
         mock_print_info.assert_called_once_with("You have been logged out.")
+
+    def test_logout_urls_from_valid_envs(self):
+        url = _logout_url("dev")
+        assert "https://bregenz.a1.cratedb-dev.cloud/oauth2/logout" == url
+
+        url = _logout_url("prod")
+        assert "https://bregenz.a1.cratedb.cloud/oauth2/logout" == url
+
+        url = _logout_url("PROD")
+        assert "https://bregenz.a1.cratedb.cloud/oauth2/logout" == url
+
+        url = _logout_url("local")
+        assert "http://localhost:8000/oauth2/logout" == url
+
+    def test_env_fallback_url(self):
+        url = _logout_url("invalid")
+        assert "https://bregenz.a1.cratedb.cloud/oauth2/logout" == url
 
 
 class TestConfigGet:

--- a/tests/unit_tests/test_session.py
+++ b/tests/unit_tests/test_session.py
@@ -25,7 +25,7 @@ from aiohttp.test_utils import loop_context
 from util.fake_server import FakeCrateDBCloud, FakeResolver
 
 from croud.config import Configuration
-from croud.session import HttpSession
+from croud.session import HttpSession, cloud_url
 
 me_query = """
 {
@@ -107,3 +107,19 @@ class TestHttpSession:
             headers = {"query": "me"}
             loop.run_until_complete(test_query())
             loop.run_until_complete(fake_cloud.stop())
+
+    def test_correct_url(self, mock_env):
+        region = "bregenz.a1"
+
+        url = cloud_url("prod", region)
+        assert url == f"https://{region}.cratedb.cloud"
+
+        url = cloud_url("dev", region)
+        assert url == f"https://{region}.cratedb-dev.cloud"
+
+        url = cloud_url("local", region)
+        assert url == "http://localhost:8000"
+
+        region = "westeurope.azure"
+        url = cloud_url("prod", region)
+        assert url == f"https://{region}.cratedb.cloud"


### PR DESCRIPTION
This adds a new environment to croud (local), which can be used for running croud against a local instance of cloud-app (via https://github.com/crate/cloud). As the configuration auth contexts have been appended to you will be logged out when using this new version as it will reformat your config file to support the local context. 