### PR TITLE
Switch uid with user argment for removing users from organizations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Changes for croud
 Unreleased
 ==========
 
+- Refactored removing users from organizations commands to parse the
+  ``user`` argument so that users can be removed via their email address
+  or user ID.
+
 0.8.1 - 2019/02/22
 ==================
 

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -267,9 +267,7 @@ command_tree = {
                     "remove": {
                         "help": "Remove user from organization",
                         "extra_args": [
-                            lambda req_opt_group, opt_opt_group: user_id_arg(
-                                req_opt_group, opt_opt_group, True
-                            ),
+                            user_id_or_email_arg,
                             lambda req_opt_group, opt_opt_group: org_id_arg(
                                 req_opt_group, opt_opt_group, False
                             ),

--- a/croud/organizations/users/commands.py
+++ b/croud/organizations/users/commands.py
@@ -61,7 +61,7 @@ def org_users_remove(args: Namespace):
     """
     ).strip()
 
-    vars = {"input": {"uid": args.user, "organizationId": args.org_id}}
+    vars = {"input": {"user": args.user, "organizationId": args.org_id}}
 
     query = Query(mutation, args)
     query.execute(vars)

--- a/tests/unit_tests/test_commands.py
+++ b/tests/unit_tests/test_commands.py
@@ -370,7 +370,7 @@ class TestOrganizations(CommandTestCase):
         ).strip()
 
         user_id = str(uuid.uuid4())
-        expected_vars = {"input": {"uid": user_id, "organizationId": None}}
+        expected_vars = {"input": {"user": user_id, "organizationId": None}}
 
         argv = ["croud", "organizations", "users", "remove", "--user", user_id]
         self.assertGql(mock_run, argv, expected_body, expected_vars)
@@ -388,7 +388,7 @@ class TestOrganizations(CommandTestCase):
 
         user_id = str(uuid.uuid4())
         org_id = str(uuid.uuid4())
-        expected_vars = {"input": {"uid": user_id, "organizationId": org_id}}
+        expected_vars = {"input": {"user": user_id, "organizationId": org_id}}
 
         argv = [
             "croud",


### PR DESCRIPTION
This PR makes it so that croud allows you to remove users from organizations via a user's email address or ID