### PR TITLE
added "croud clusters deploy" command

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for croud
 Unreleased
 ==========
 
+- Added ``clusters deploy`` command that allows users to deploy a new
+  CrateDB cluster.
+
 - Make ``--org-id`` and ``--no-org`` arguments mutually exclusive for the
   ``users list`` command and print an error if both arguments are provided.
 

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -25,10 +25,11 @@ import sys
 
 import colorama
 
-from croud.clusters.commands import clusters_list
+from croud.clusters.commands import clusters_deploy, clusters_list
 from croud.cmd import (
     CMD,
     cluster_id_arg,
+    cluster_name_arg,
     consumer_eventhub_connection_string_arg,
     consumer_eventhub_consumer_group_arg,
     consumer_eventhub_lease_storage_connection_string_arg,
@@ -101,7 +102,9 @@ command_tree = {
                 "extra_args": [
                     output_fmt_arg,
                     product_tier_arg,
-                    product_unit_arg,
+                    lambda req_opt_group, opt_opt_group: product_unit_arg(
+                        req_opt_group, opt_opt_group, True
+                    ),
                     product_name_arg,
                     lambda req_opt_group, opt_opt_group: project_id_arg(
                         req_opt_group, opt_opt_group, True
@@ -232,6 +235,28 @@ command_tree = {
                                ),
                                region_arg],
                 "calls": clusters_list,
+            },
+            "deploy": {
+                "help": "Deploys a new CrateDB cluster.",
+                "extra_args": [
+                    output_fmt_arg,
+                    region_arg,
+                    product_name_arg,
+                    product_tier_arg,
+                    lambda req_opt_group, opt_opt_group: product_unit_arg(
+                        req_opt_group, opt_opt_group, False
+                    ),
+                    lambda req_opt_group, opt_opt_group: project_id_arg(
+                        req_opt_group, opt_opt_group, True
+                    ),
+                    lambda req_opt_group, opt_opt_group: cluster_name_arg(
+                        req_opt_group, opt_opt_group, True
+                    ),
+                    crate_version_arg,
+                    crate_username_arg,
+                    crate_password_arg,
+                ],
+                "calls": clusters_deploy,
             }
         },
     },

--- a/croud/clusters/commands.py
+++ b/croud/clusters/commands.py
@@ -57,3 +57,41 @@ def clusters_list(args: Namespace) -> None:
     query = Query(body, args)
     query.execute(vars)
     print_query(query, "allClusters")
+
+
+def clusters_deploy(args: Namespace) -> None:
+    """
+    Deploys a new cluster CrateDB cluster.
+    """
+
+    mutation = textwrap.dedent(
+        """
+        mutation deployCluster($input: DeployClusterInput!) {
+            deployCluster(input: $input) {
+                id
+                name
+                fqdn
+                url
+            }
+        }
+    """  # noqa
+    ).strip()
+
+    vars = clean_dict(
+        {
+            "input": {
+                "productName": args.product_name,
+                "tier": args.tier,
+                "unit": args.unit,
+                "name": args.cluster_name,
+                "projectId": args.project_id,
+                "username": args.username,
+                "password": args.password,
+                "version": args.version,
+            }
+        }
+    )
+
+    query = Query(mutation, args)
+    query.execute(vars)
+    print_query(query, "deployCluster")

--- a/croud/cmd.py
+++ b/croud/cmd.py
@@ -317,6 +317,15 @@ def cluster_id_arg(
     )
 
 
+def cluster_name_arg(
+    req_args: _ArgumentGroup, opt_args: _ArgumentGroup, required: bool
+) -> None:
+    group = req_args if required else opt_args
+    group.add_argument(
+        "--cluster-name", type=str, help="CrateDB cluster name", required=required
+    )
+
+
 def product_id_arg(
     req_args: _ArgumentGroup, opt_args: _ArgumentGroup, required: bool
 ) -> None:
@@ -328,8 +337,13 @@ def product_tier_arg(req_args: _ArgumentGroup, opt_args: _ArgumentGroup) -> None
     req_args.add_argument("--tier", type=str, help="Product Tier.", required=True)
 
 
-def product_unit_arg(req_args: _ArgumentGroup, opt_args: _ArgumentGroup) -> None:
-    req_args.add_argument("--unit", type=int, help="Product Scale Unit.", required=True)
+def product_unit_arg(
+    req_args: _ArgumentGroup, opt_args: _ArgumentGroup, required: bool
+) -> None:
+    group = req_args if required else opt_args
+    group.add_argument(
+        "--unit", type=int, help="Product Scale Unit.", required=required
+    )
 
 
 def product_name_arg(req_args: _ArgumentGroup, opt_args: _ArgumentGroup) -> None:

--- a/docs/docs/commands.txt
+++ b/docs/docs/commands.txt
@@ -408,6 +408,12 @@ Available options:
 |                                                       |          | - ``table``                              |
 +-------------------------------------------------------+----------+------------------------------------------+
 
+.. TIP:
+
+    Be careful when specifying passwords on the command line. Some
+    non-alphanumeric characters may be interpreted in an unexpected way by your
+    shell. Use `string delimitation`_ and escape characters as needed.
+
 .. _consumer-sets:
 
 ``consumer-sets``
@@ -688,6 +694,61 @@ You must specify a subcommand, like so:
 
     sh$ croud clusters [SUBCOMMAND] [OPTIONS]
 
+.. clusters.deploy:
+
+``deploy``
+----------
+
+The ``deploy`` subcommand deploys a new CrateDB cluster:
+
+.. code-block: console
+
+    sh$ croud clusters deploy [OPTIONS]
+
+Available options:
+
++-------------------------------+----------+----------------------------------+
+| Option                        | Required | Description                      |
++===============================+==========+==================================+
+| ``--product-name <STRING>``   | Yes      | The name of the desired CrateDB  |
+|                               |          |  product.                        |
++-------------------------------+----------+----------------------------------+
+| ``--tier <STRING>``           | Yes      | The tier of the deployed product.|
+|                               |          |                                  |
+|                               |          | One of:                          |
+|                               |          |                                  |
+|                               |          | - ``XS``                         |
+|                               |          | - ``S``                          |
+|                               |          | - ``M``                          |
+|                               |          | - ``L``                          |
+|                               |          | - ``XL``                         |
++-------------------------------+----------+----------------------------------+
+| ``--project-id <STRING>``     | Yes      | The identifier of the project in |
+|                               |          | which the product should be      |
+|                               |          | deployed.                        |
++-------------------------------+----------+----------------------------------+
+| ``--cluster-name <STRING>``   | Yes      | The CrateDB cluster name.        |
+|                               |          |                                  |
++-------------------------------+----------+----------------------------------+
+| ``--username <STRING>``       | Yes      | The database username for        |
+|                               |          | CrateDB.                         |
++-------------------------------+----------+----------------------------------+
+| ``--password <STRING>``       | Yes      | The password for the given       |
+|                               |          | database user.                   |
++-------------------------------+----------+----------------------------------+
+| ``--version <STRING>``        | Yes      | The version of CrateDB.          |
+|                               |          |                                  |
++-------------------------------+----------+----------------------------------+
+| ``--unit <STRING>``           | No       | The scale unit of the deployed   |
+|                               |          | product.                         |
++-------------------------------+----------+----------------------------------+
+
+.. TIP:
+
+    Be careful when specifying passwords on the command line. Some
+    non-alphanumeric characters may be interpreted in an unexpected way by your
+    shell. Use `string delimitation`_ and escape characters as needed.
+
 .. clusters.list:
 
 ``list``
@@ -796,7 +857,6 @@ Available options:
 |                           |          | - ``json``                 |
 |                           |          | - ``table``                |
 +---------------------------+----------+----------------------------+
-
 
 .. users.roles:
 
@@ -970,3 +1030,4 @@ This output format looks like this:
 
 .. _CrateDB Cloud: https://crate.io/products/cratedb-cloud/
 .. _fully qualified role name: https://en.wikipedia.org/wiki/Fully_qualified_name
+.. _string delimitation: https://en.wikipedia.org/wiki/Delimiter

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,10 @@ setup(
         "tabulate==0.8.2",
         "schema==0.6.8",
     ],
-    extras_require={"testing": ["tox==3.6.1"], "development": ["black==18.9b0"]},
+    extras_require={
+        "testing": ["tox==3.6.1", "black==18.9b0"],
+        "development": ["black==18.9b0"],
+    },
     python_requires=">=3.6",
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,4 +6,4 @@ pytest-black
 pytest-mypy
 pytest-aiohttp
 mypy
-black
+black==18.9b0

--- a/tests/unit_tests/test_commands.py
+++ b/tests/unit_tests/test_commands.py
@@ -218,6 +218,59 @@ class TestClusters(CommandTestCase):
         }
         self.assertGql(mock_run, argv, self.expected_body, expected_vars)
 
+    def test_crate_clusters(self, mock_run, mock_load_config):
+        expected_body = textwrap.dedent(
+            """
+            mutation deployCluster($input: DeployClusterInput!) {
+                deployCluster(input: $input) {
+                    id
+                    name
+                    fqdn
+                    url
+                }
+            }
+        """  # noqa
+        ).strip()
+
+        project_id = gen_uuid()
+
+        expected_vars = {
+            "input": {
+                "productName": "crate-default",
+                "tier": "S0",
+                "unit": 1,
+                "name": "crate_cluster",
+                "projectId": project_id,
+                "username": "foobar",
+                "password": "s3cr3t!",
+                "version": "3.2.5",
+            }
+        }
+
+        argv = [
+            "croud",
+            "clusters",
+            "deploy",
+            "--product-name",
+            "crate-default",
+            "--tier",
+            "S0",
+            "--unit",
+            "1",
+            "--project-id",
+            project_id,
+            "--cluster-name",
+            "crate_cluster",
+            "--version",
+            "3.2.5",
+            "--username",
+            "foobar",
+            "--password",
+            "s3cr3t!",
+        ]
+
+        self.assertGql(mock_run, argv, expected_body, expected_vars)
+
 
 @mock.patch("croud.config.load_config", return_value=Configuration.DEFAULT_CONFIG)
 @mock.patch.object(Query, "run", return_value={"data": []})


### PR DESCRIPTION
This PR is should only be merged once the backend functionality is available in the cloud-app!

## Summary of the changes / Why this is an improvement
Added the command ``croud clusters deploy`` to enable users to deploy a new CrateDB cluster.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed 