### PR TITLE
restore old formatting of command help

### DIFF
--- a/tests/unit_tests/util/__init__.py
+++ b/tests/unit_tests/util/__init__.py
@@ -1,6 +1,24 @@
 import argparse
+import difflib
+import re
+from doctest import _ellipsis_match  # type: ignore
+from functools import partial
 
 from croud.__main__ import get_parser
+
+normalize = partial(re.sub, r"\s+", "")
+
+
+def ndiff(actual: str, expected: str) -> str:
+    engine = difflib.Differ(charjunk=difflib.IS_CHARACTER_JUNK)
+    diff = list(engine.compare(expected.splitlines(True), actual.splitlines(True)))
+    return "\n".join(line.rstrip() for line in diff)
+
+
+def assert_ellipsis_match(actual: str, expected: str) -> None:
+    diff = ndiff(expected.strip(), actual.strip())
+    equality = _ellipsis_match(normalize(expected.strip()), normalize(actual.strip()))
+    assert equality, diff
 
 
 class CommandTestCase:


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

A regression that caused the command help not showing required and
optional arguments correctly was introduced with commit #747f876