### PR TITLE
docs: update extra css files in html_context of the theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ master_doc = 'index'
 
 html_static_path = ['_static']
 html_context = {
-    'css_files': [
+    'extra_css_files': [
         '_static/sphinxarg.css',  # overrides
     ],
 }

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,7 +1,6 @@
-crate-docs-theme>=0.5.70,<0.6.0
+crate-docs-theme>=0.5.74
 
 # packages for local dev
-
 sphinx-autobuild==0.6.0
 
 # the next section should exact copy of the hosted RTD environment (please


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This commit fixes a regression that was introduced in version 0.5.73 of
the crate-docs-theme and was resolved in 0.5.74, which caused the RTD
version widget to be rendered at the bottom of the page.