### PR TITLE
make the `config get` commands respect the output format

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changes for croud
 Unreleased
 ==========
 
+- Make the ``config get`` commands respect the output format option.
+
 0.11.0 - 2019/04/17
 ===================
 

--- a/croud/config.py
+++ b/croud/config.py
@@ -24,7 +24,7 @@ import yaml
 from appdirs import user_config_dir
 from schema import Schema, SchemaError
 
-from croud.printer import print_error, print_info
+from croud.printer import print_error, print_format, print_info
 
 
 class IncompatibleConfigException(Exception):
@@ -173,7 +173,9 @@ def config_get(args: Namespace):
     Gets a default configuration setting
     """
 
-    print(Configuration.get_setting(args.get))
+    fmt = Configuration.get_setting("output_fmt")
+    value = Configuration.get_setting(args.get)
+    print_format([{args.get: value}], args.output_fmt or fmt)
 
 
 def config_set(args: Namespace):

--- a/croud/parser.py
+++ b/croud/parser.py
@@ -103,7 +103,11 @@ def add_default_args(parser):
         help="Switches auth context.",
     )
     parser._group_optional.add_argument(
-        "--output-fmt", "-o", required=False, choices={"table", "json"}
+        "--output-fmt",
+        "-o",
+        required=False,
+        choices={"table", "json"},
+        help="Change the formatting of the output",
     )
 
 

--- a/croud/printer.py
+++ b/croud/printer.py
@@ -26,7 +26,7 @@ from tabulate import tabulate
 from croud.typing import JsonDict
 
 
-def print_format(rows: Union[List[JsonDict], JsonDict], format: str = "json") -> None:
+def print_format(rows: Union[List[JsonDict], JsonDict], format: str) -> None:
     printer = FormatPrinter()
     printer.print_rows(rows, format)
 
@@ -76,9 +76,9 @@ class FormatPrinter:
             # [{"a": "foo", "b": 1}, {"a": "bar", "b": "1"}]
             # +-----+-----+
             # | a   |   b |
-            # |-----+-----+
+            # |-----+-----|
             # | foo |   1 |
-            # +-----+-----+
+            # |-----+-----|
             # | bar |   2 |
             # +-----+-----+
             headers = list(map(str, iter(rows[0].keys())))

--- a/docs/commands/config.rst
+++ b/docs/commands/config.rst
@@ -26,7 +26,11 @@ Example
 .. code-block:: console
 
    $ croud config get env
-   prod
+   +--------+
+   | env    |
+   |--------|
+   | prod   |
+   +--------+
 
 
 ``config set``

--- a/tests/unit_tests/test_commands.py
+++ b/tests/unit_tests/test_commands.py
@@ -39,14 +39,34 @@ class TestConfigGet:
     @mock.patch("croud.config.load_config", return_value=Configuration.DEFAULT_CONFIG)
     @mock.patch("builtins.print", autospec=True, side_effect=print)
     def test_get_env(self, mock_print, mock_load_config):
-        config_get(Namespace(get="env"))
-        mock_print.assert_called_once_with("prod")
+        config_get(Namespace(get="env", output_fmt=None))
+        mock_print.assert_called_once_with(
+            textwrap.dedent(
+                """
+                +-------+
+                | env   |
+                |-------|
+                | prod  |
+                +-------+
+            """
+            ).strip()
+        )
 
     @mock.patch("croud.config.load_config", return_value=Configuration.DEFAULT_CONFIG)
     @mock.patch("builtins.print", autospec=True, side_effect=print)
     def test_get_top_level_setting(self, mock_print, mock_load_config):
-        config_get(Namespace(get="region"))
-        mock_print.assert_called_once_with("bregenz.a1")
+        config_get(Namespace(get="region", output_fmt=None))
+        mock_print.assert_called_once_with(
+            textwrap.dedent(
+                """
+                +------------+
+                | region     |
+                |------------|
+                | bregenz.a1 |
+                +------------+
+            """
+            ).strip()
+        )
 
 
 class TestConfigSet:


### PR DESCRIPTION
Example:

```console
$ croud config get env
+-------+
| env   |
|-------|
| dev   |
+-------+

$ croud config get env -o json
[
  {
    "env": "dev"
  }
]
```

## Summary of the changes / Why this is an improvement


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
