### PR TITLE
Fixed redirect error and error response handling in Grafana REST API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Unreleased
 
 - Make the ``config get`` commands respect the output format option.
 
+- Fixed API redirect and error response bug for ``monitoring grafana`` command.
+
 0.11.0 - 2019/04/17
 ===================
 

--- a/croud/monitoring/grafana/commands.py
+++ b/croud/monitoring/grafana/commands.py
@@ -27,5 +27,5 @@ def set_grafana(enable: bool, args: Namespace) -> None:
     method = RequestMethod.POST if enable else RequestMethod.DELETE
 
     client = Client(env=args.env, region=args.region, output_fmt=args.output_fmt)
-    client.send(method, "/api/v2/monitoring/grafana", {"project_id": args.project_id})
+    client.send(method, "/api/v2/monitoring/grafana/", {"project_id": args.project_id})
     client.print()

--- a/tests/unit_tests/test_commands.py
+++ b/tests/unit_tests/test_commands.py
@@ -779,7 +779,7 @@ class TestGrafana(CommandTestCase):
             mock_send,
             argv,
             RequestMethod.POST,
-            "/api/v2/monitoring/grafana",
+            "/api/v2/monitoring/grafana/",
             {"project_id": self.project_id},
         )
 
@@ -796,6 +796,6 @@ class TestGrafana(CommandTestCase):
             mock_send,
             argv,
             RequestMethod.DELETE,
-            "/api/v2/monitoring/grafana",
+            "/api/v2/monitoring/grafana/",
             {"project_id": self.project_id},
         )

--- a/tests/unit_tests/util/__init__.py
+++ b/tests/unit_tests/util/__init__.py
@@ -42,4 +42,8 @@ class CommandTestCase:
 
     def assertRest(self, mock_send, argv, method, endpoint, body=None):
         self.execute(argv)
-        mock_send.assert_called_once_with(method, endpoint, body)
+
+        args = [method, endpoint]
+        if body is not None:
+            args.append(body)
+        mock_send.assert_called_once_with(*args)

--- a/tests/unit_tests/util/fake_server.py
+++ b/tests/unit_tests/util/fake_server.py
@@ -114,7 +114,10 @@ class FakeCrateDBCloud:
 
     async def error_400(self, request: web.Request) -> web.Response:
         if self._is_authorized(request):
-            return web.json_response({"error": {"message": "Bad request."}}, status=400)
+            return web.json_response(
+                {"message": "Bad request.", "errors": {"key": "Error on 'key'"}},
+                status=400,
+            )
         return web.Response(status=302)
 
     async def text_response(self, request: web.Request) -> web.Response:


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

To be back-ported to 0.11.x.


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
