### PR TITLE
prepare release 0.11.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for croud
 Unreleased
 ==========
 
+0.11.1 - 2019/05/02
+===================
+
 - Fixed API redirect and error response bug for ``monitoring grafana`` command.
 
 0.11.0 - 2019/04/17


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

- Fixed API redirect and error response bug for ``monitoring grafana`` command.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
