### PR TITLE
Mock out event loop when running logout test

### DIFF
--- a/tests/unit_tests/test_authentication.py
+++ b/tests/unit_tests/test_authentication.py
@@ -164,8 +164,9 @@ class TestLogin:
 
 
 class TestLogout:
+    @mock.patch("croud.logout.asyncio.get_event_loop")
     @mock.patch("croud.logout.print_info")
-    def test_logout(self, mock_print_info):
+    def test_logout(self, mock_print_info, mock_loop):
         conf = {
             "auth": {
                 "current_context": "prod",


### PR DESCRIPTION
This is required to ensure we're not actually hitting a real API
endpoint.