### PR TITLE
Added croud products list command

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for croud
 Unreleased
 ==========
 
+- Added ``croud products list`` command to list all available products
+ in the current region.
+
 0.12.1 - 2019/05/22
 ===================
 

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -36,6 +36,7 @@ from croud.cmd import (
     crate_version_arg,
     eventhub_consumer_group_arg,
     eventhub_dsn_arg,
+    kind_arg,
     lease_storage_container_arg,
     lease_storage_dsn_arg,
     num_instances_arg,
@@ -62,6 +63,7 @@ from croud.monitoring.grafana.commands import set_grafana
 from croud.organizations.commands import organizations_create, organizations_list
 from croud.organizations.users.commands import org_users_add, org_users_remove
 from croud.parser import create_parser
+from croud.products.commands import products_list
 from croud.projects.commands import project_create, projects_list
 from croud.projects.users.commands import project_user_add, project_user_remove
 from croud.users.commands import users_list
@@ -264,6 +266,16 @@ command_tree = {
                 ],
                 "resolver": clusters_deploy,
             }
+        },
+    },
+    "products": {
+        "help": "Manage Products.",
+        "commands": {
+            "list": {
+                "help": "List all available products in the current region.",
+                "extra_args": [kind_arg],
+                "resolver": products_list,
+            },
         },
     },
     "organizations": {

--- a/croud/cmd.py
+++ b/croud/cmd.py
@@ -281,3 +281,7 @@ def num_instances_arg(req_args: _ArgumentGroup, opt_args: _ArgumentGroup) -> Non
         default=1,
         required=False,
     )
+
+
+def kind_arg(req_args: _ArgumentGroup, opt_args: _ArgumentGroup) -> None:
+    opt_args.add_argument("--kind", type=str, help="The product kind.", required=False)

--- a/croud/products/commands.py
+++ b/croud/products/commands.py
@@ -1,0 +1,37 @@
+# Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+from argparse import Namespace
+
+from croud.rest import Client
+from croud.session import RequestMethod
+
+
+def products_list(args: Namespace) -> None:
+    """
+    Lists available products
+    """
+
+    client = Client(env=args.env, region=args.region, output_fmt=args.output_fmt)
+    url = "/api/v2/products/"
+    if args.kind:
+        client.send(RequestMethod.GET, url, params={"kind": args.kind})
+    else:
+        client.send(RequestMethod.GET, url)
+    client.print(keys=["kind", "name", "tier", "description"])

--- a/docs/commands/index.rst
+++ b/docs/commands/index.rst
@@ -48,4 +48,5 @@ To get help for a specific command, you can append ``--help``:
    monitoring
    organizations
    projects
+   products
    users

--- a/docs/commands/products.rst
+++ b/docs/commands/products.rst
@@ -1,0 +1,37 @@
+============
+``products``
+============
+
+The ``products`` command allows you to view the available products.
+
+.. argparse::
+   :module: croud.__main__
+   :func: get_parser
+   :prog: croud
+   :path: products
+   :nosubcommands:
+
+
+``products list``
+=================
+
+.. argparse::
+   :module: croud.__main__
+   :func: get_parser
+   :prog: croud
+   :path: products list
+
+Example
+-------
+
+.. code-block:: console
+
+    sh$ croud products list --kind "cluster" --region "eastus.azure"
+    +-----------------------------------------+---------+-------------+--------+
+    | description                             | kind    | name        | tier   |
+    |-----------------------------------------+---------+-------------+--------|
+    | A CrateDB cluster with standard storage | cluster | cratedb.az1 | xs     |
+    | A CrateDB cluster with standard storage | cluster | cratedb.az1 | s      |
+    | A CrateDB cluster with standard storage | cluster | cratedb.az1 | m      |
+    | A CrateDB cluster with standard storage | cluster | cratedb.az1 | l      |
+    +-----------------------------------------+---------+-------------+--------+

--- a/tests/unit_tests/test_commands.py
+++ b/tests/unit_tests/test_commands.py
@@ -764,3 +764,23 @@ class TestGrafana(CommandTestCase):
             "/api/v2/monitoring/grafana/",
             body={"project_id": self.project_id},
         )
+
+
+@mock.patch("croud.config.load_config", return_value=Configuration.DEFAULT_CONFIG)
+@mock.patch.object(Query, "run", return_value={"data": []})
+class TestProducts(CommandTestCase):
+    @mock.patch.object(Client, "send")
+    def test_list(self, mock_send, mock_run, mock_load_config):
+        argv = ["croud", "products", "list"]
+        self.assertRest(mock_send, argv, RequestMethod.GET, "/api/v2/products/")
+
+    @mock.patch.object(Client, "send")
+    def test_list_kind(self, mock_send, mock_run, mock_load_config):
+        argv = ["croud", "products", "list", "--kind", "cluster"]
+        self.assertRest(
+            mock_send,
+            argv,
+            RequestMethod.GET,
+            "/api/v2/products/",
+            params={"kind": "cluster"},
+        )


### PR DESCRIPTION
this command list all available products in the current region.
usage:

    croud products list --kind "cluster" --region "eastus.azure"

## Summary of the changes / Why this is an improvement


## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
