### PR TITLE
Fix console output for delete requests

### DIFF
--- a/croud/rest.py
+++ b/croud/rest.py
@@ -101,7 +101,10 @@ class Client:
                 return await resp.json()
             # API always returns JSON, unless there's an unhandled server error
             except ContentTypeError:
-                return {"message": "Invalid response type.", "success": False}
+                if resp.status == 204:
+                    return {"success": True}
+                else:
+                    return {"message": "Invalid response type.", "success": False}
 
         loop = asyncio.get_event_loop()
         return loop.run_until_complete(_decode())

--- a/tests/unit_tests/test_rest.py
+++ b/tests/unit_tests/test_rest.py
@@ -81,6 +81,13 @@ class TestRestClient:
                 "success": False,
             }
 
+    def test_send_empty_response(self, mock_cloud_url, mock_token):
+        with mock.patch.object(HttpSession, "_get_conn", return_value=self._get_conn()):
+            client = Client(env="dev", region="bregenz.a1", output_fmt="json")
+            client.send(RequestMethod.GET, "/empty-response")
+
+            assert client._data == {"success": True}
+
     def _get_conn(self):
         return TCPConnector(loop=self.loop, resolver=self.resolver, ssl=True)
 

--- a/tests/unit_tests/util/fake_server.py
+++ b/tests/unit_tests/util/fake_server.py
@@ -65,6 +65,7 @@ class FakeCrateDBCloud:
         self.app.router.add_routes([web.get("/data/no-key", self.data_no_key)])
         self.app.router.add_routes([web.get("/errors/400", self.error_400)])
         self.app.router.add_routes([web.get("/text-response", self.text_response)])
+        self.app.router.add_routes([web.get("/empty-response", self.empty_response)])
 
         here = pathlib.Path(__file__)
         # Load certificates and sign key used to simulate ssl/tls
@@ -123,6 +124,11 @@ class FakeCrateDBCloud:
     async def text_response(self, request: web.Request) -> web.Response:
         if self._is_authorized(request):
             return web.Response(body="Non JSON response.", status=500)
+        return web.Response(status=302)
+
+    async def empty_response(self, request: web.Request) -> web.Response:
+        if self._is_authorized(request):
+            return web.Response(body="", status=204)
         return web.Response(status=302)
 
     def _is_authorized(self, request: web.Request) -> bool:


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

When a request returns 204 it has no body, which returns an error
message saying that the request was not successful. If a response has an
empty body it will now check if the return code is 204 and returns
success.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
