### PR TITLE
H/session

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Changes for croud
 Unreleased
 ==========
 
+- Fix client session so it stores the refreshed access token in the
+  configuration. This prevents the server from refreshing the access token sent
+  by the client in case it was already expired.
+
 - Added ``consumers delete`` command to delete existing consumers.
 
 - Added ``croud products list`` command to list all available products

--- a/croud/gql.py
+++ b/croud/gql.py
@@ -51,7 +51,9 @@ class Query:
         self._response: Optional[JsonDict] = None
 
     async def _fetch_data(self, body: str, variables: Optional[Dict]) -> JsonDict:
-        async with HttpSession(self._env, self._token, self._region) as session:
+        async with HttpSession(
+            self._env, self._token, self._region, on_new_token=Configuration.set_token
+        ) as session:
             resp = await session.fetch(
                 RequestMethod.POST,
                 self._endpoint,

--- a/croud/rest.py
+++ b/croud/rest.py
@@ -36,10 +36,13 @@ class Client:
     _data: Optional[Union[List[dict], dict]] = None
     _error: Optional[dict] = None
 
-    def __init__(self, env: str = None, region: str = None, output_fmt: str = None):
+    def __init__(
+        self, env: str = None, region: str = None, output_fmt: str = None, loop=None
+    ):
         self._env = env or Configuration.get_env()
         self._region = region or Configuration.get_setting("region")
         self._output_fmt = output_fmt or Configuration.get_setting("output_fmt")
+        self.loop = loop or asyncio.get_event_loop()
 
     def send(
         self,
@@ -83,8 +86,9 @@ class Client:
         body: dict = None,
         params: dict = None,
     ) -> ClientResponse:
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self._fetch_data(method, endpoint, body, params))
+        return self.loop.run_until_complete(
+            self._fetch_data(method, endpoint, body, params)
+        )
 
     async def _fetch_data(
         self,
@@ -106,5 +110,4 @@ class Client:
             except ContentTypeError:
                 return {"message": "Invalid response type.", "success": False}
 
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(_decode())
+        return self.loop.run_until_complete(_decode())

--- a/croud/rest.py
+++ b/croud/rest.py
@@ -81,7 +81,10 @@ class Client:
         params: dict = None,
     ) -> ClientResponse:
         async with HttpSession(
-            self._env, Configuration.get_token(), self._region
+            self._env,
+            Configuration.get_token(),
+            self._region,
+            on_new_token=Configuration.set_token,
         ) as session:
             return await session.fetch(method, endpoint, body, params)
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,6 +5,6 @@ pytest-isort==0.2.1
 pytest-black==0.3.5
 pytest-mypy==0.3.2
 pytest-aiohttp==0.3.0
+pytest-asyncio==0.10.0
 mypy==0.670
 black==19.3b0
-asynctest==0.12.2

--- a/tests/unit_tests/test_rest.py
+++ b/tests/unit_tests/test_rest.py
@@ -94,8 +94,8 @@ class TestRestClient:
 
 @mock.patch("croud.rest.print_success")
 @mock.patch("croud.rest.print_format")
-def test_print_success(mock_print_format, mock_print_success):
-    client = Client(env="dev", region="bregenz.a1", output_fmt="json")
+def test_print_success(mock_print_format, mock_print_success, event_loop):
+    client = Client(env="dev", region="bregenz.a1", output_fmt="json", loop=event_loop)
 
     client._data = {"key": "value"}
     client.print()
@@ -111,8 +111,8 @@ def test_print_success(mock_print_format, mock_print_success):
 
 
 @mock.patch("croud.rest.print_error")
-def test_print_error(mock_print_error):
-    client = Client(env="dev", region="bregenz.a1", output_fmt="json")
+def test_print_error(mock_print_error, event_loop):
+    client = Client(env="dev", region="bregenz.a1", output_fmt="json", loop=event_loop)
 
     error = {"message": "Bad request.", "errors": {"key": "Error on 'key'"}}
     client._error = error
@@ -121,8 +121,8 @@ def test_print_error(mock_print_error):
 
 
 @mock.patch("croud.rest.print_format")
-def test_print_error_no_message(mock_print_format):
-    client = Client(env="dev", region="bregenz.a1", output_fmt="json")
+def test_print_error_no_message(mock_print_format, event_loop):
+    client = Client(env="dev", region="bregenz.a1", output_fmt="json", loop=event_loop)
 
     error = {"errors": {"key": "Error on 'key'"}}
     client._error = error

--- a/tests/unit_tests/test_session.py
+++ b/tests/unit_tests/test_session.py
@@ -17,6 +17,7 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+from http.cookies import Morsel
 from unittest import mock
 
 import aiohttp
@@ -136,3 +137,16 @@ class TestHttpSession:
         region = "westeurope.azure"
         url = cloud_url("prod", region)
         assert url == f"https://{region}.cratedb.cloud"
+
+
+@pytest.mark.asyncio
+async def test_on_new_token():
+    update_config = mock.Mock()
+    async with HttpSession(
+        "dev", "old_token", "eastus.azure", on_new_token=update_config
+    ) as session:
+        session_cookie = Morsel()
+        session_cookie.set("session", "new_token", None)
+        session.client.cookie_jar.update_cookies({"session": session_cookie})
+
+    update_config.assert_called_once_with("new_token")


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This PR fixes the problem, that the client did not store the
refreshed access token from the server.
This caused long latencies for API calls in case the access token from
the client was expired, because the server had to refresh it on each
request.

Additional there are two other small cleanup commits.

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
