### PR TITLE
fix a regression of the output when deleting resources

### DIFF
--- a/tests/unit_tests/test_rest.py
+++ b/tests/unit_tests/test_rest.py
@@ -76,6 +76,7 @@ class TestRestClient:
             client = Client(env="dev", region="bregenz.a1", output_fmt="json")
             client.send(RequestMethod.GET, "/text-response")
 
+            assert client._data is None
             assert client._error == {
                 "message": "Invalid response type.",
                 "success": False,
@@ -86,7 +87,8 @@ class TestRestClient:
             client = Client(env="dev", region="bregenz.a1", output_fmt="json")
             client.send(RequestMethod.GET, "/empty-response")
 
-            assert client._data == {"success": True}
+            assert client._data is None
+            assert client._error is None
 
     def _get_conn(self):
         return TCPConnector(loop=self.loop, resolver=self.resolver, ssl=True)


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This commit fixes an unreleased regression of the console output of the
`consumers delete` command that printed a response table instead of a
simple success message.

Output before the commit:

```console
$ croud consumers delete --consumer-id ... --yes
+-----------+
| success   |
|-----------|
| TRUE      |
+-----------+
```

Output after the fix:

```console
$ croud consumers delete --consumer-id ...
Are you sure you want to delete the consumer? [yN] y
==> Success: Consumer deleted.
```


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
