### PR TITLE
Replace setuptools_scm with manual version management

### DIFF
--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -25,8 +25,8 @@ Run it::
 Git
 ---
 
-Alternatively, you can clone this repository, install it into a virtualenv and add the executable to your PATH
-environment variable::
+Alternatively, you can clone this repository, install it into a virtualenv and
+add the executable to your PATH environment variable::
 
     git clone git@github.com:crate/croud.git && cd croud/
     python3.6 -m venv env
@@ -55,20 +55,18 @@ fraction of tests with python3.6::
 Release
 =======
 
-This project uses `setuptools_scm`_ for managing the package version from scm
-metadata.
+#. Create a new branch named ``<prefix>/prepare-x.y.z``.
 
-1. Create a new branch named <prefix>/prepare-x.y.z
+#. Update the ``__version__`` in ``setup.py``.
 
-2. Add new section to ``CHANGES.rst`` with the version and release date in the
-   format ``x.y.z - yyyy/mm/dd``
+#. Add new section to ``CHANGES.rst`` with the version and release date in the
+   format ``x.y.z - yyyy/mm/dd``.
 
-3. Create a PR against ``master`` or version branch (e.g. ``0.1``).
+#. Create a PR against ``master`` or version branch (e.g. ``0.1``).
 
-4. After PR is merged, tag the release::
+#. After PR is merged, tag the release by running::
 
-    git tag -a "<VERSION>" -m "Tag for version <VERSION>"
-    git push --tags
+    ./dev/tools/create_tag.sh
 
 
 Upload to `PyPI`_
@@ -82,7 +80,6 @@ See the instructions for `Generating distribution archives`_ for more details.
     for experimentation and testing.
 
 .. _pytest: https://docs.pytest.org/en/latest/
-.. _setuptools_scm: https://github.com/pypa/setuptools_scm
 .. _tox: https://tox.readthedocs.io
 .. _Generating distribution archives: https://packaging.python.org/tutorials/packaging-projects/#generating-distribution-archives
 .. _PyPI: https://pypi.org/project/croud/

--- a/dev/tools/create_tag.sh
+++ b/dev/tools/create_tag.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Version: 0.1
+
+function print_error() {
+  echo -e "\033[31mERROR:\033[0m $1"
+}
+
+function print_info() {
+  echo -e "\033[32mINFO:\033[0m  $1"
+}
+
+# check if everything is committed
+if ! [[ -z "$(git status -s)" ]]; then
+  print_error "Working directory not clean."
+  print_error "Please commit all changes before tagging."
+  exit 1
+fi
+
+print_info "Fetching origin ..."
+git fetch origin > /dev/null
+
+# get current branch
+BRANCH=`git branch | grep "^*" | cut -d " " -f 2`
+print_info "Current branch is $BRANCH."
+
+# check if local branch is origin branch
+LOCAL_COMMIT=`git show --format="%H" $BRANCH`
+ORIGIN_COMMIT=`git show --format="%H" origin/$BRANCH`
+
+if [[ "$LOCAL_COMMIT" != "$ORIGIN_COMMIT" ]]; then
+  print_error "Local $BRANCH is not up to date."
+  exit 1
+fi
+
+# check if tag to create has already been created
+if ! [[ -x $(command -v python3) ]]; then
+  print_error "Python 3 could not be found."
+  exit 1
+fi
+PKG_DIR="$(dirname $0)/../.."
+VERSION=$(python3 $PKG_DIR/setup.py --version)
+print_info "Package version is $VERSION"
+
+if [[ "$VERSION" == "$(git tag | grep $VERSION)" ]]; then
+  print_error "Version $VERSION already tagged."
+  exit 1
+fi
+
+# check if VERSION is in head of CHANGES.rst
+REV_NOTE=$(grep -E "$VERSION - [0-9/]{10}" CHANGES.rst)
+if [[ -z "$REV_NOTE" ]]; then
+  print_error "No notes for version $VERSION found in CHANGES.rst."
+  exit 1
+fi
+print_info "Changelog section: $REV_NOTE"
+
+print_info "Creating tag $VERSION ..."
+
+git tag -a "$VERSION" -m "Tag for version $VERSION"
+git push --tags
+
+print_info "Done."

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,10 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+from pkg_resources.extern.packaging.version import Version
 from setuptools import find_packages, setup
+
+__version__ = Version("0.14.dev0")
 
 try:
     with open("README.rst", "r", encoding="utf-8") as f:
@@ -35,6 +38,7 @@ setup(
     url="https://github.com/crate/croud",
     description="A command line interface for CrateDB Cloud",
     long_description=readme,
+    version=str(__version__),
     entry_points={"console_scripts": ["croud = croud.__main__:main"]},
     packages=find_packages(),
     install_requires=[
@@ -61,6 +65,4 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
     ],
-    use_scm_version=True,
-    setup_requires=["setuptools_scm"],
 )


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Croud used to use [setuptools_scm](https://pypi.org/project/setuptools-scm/)
for handling the Python package version instead of declaring it manually
in the `setup.py` file.

This commit removes the setup requirement and switches to manually
declared versions. The reason for that is to use the same tooling for
tagging and releasing this package, that we use also for other packages.
This change therefore also adds a script to create a tag automatically,
which is located in `dev/tools/create_tag.sh`.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
