### PR TITLE
Added clusters upgrade command

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for croud
 Unreleased
 ==========
 
+- Added ``clusters upgrade`` command to update an existing cluster to a later
+  version.
+
 0.13.2 - 2019/06/04
 ===================
 

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -28,6 +28,7 @@ from croud.clusters.commands import (
     clusters_deploy,
     clusters_list,
     clusters_scale,
+    clusters_upgrade,
 )
 from croud.cmd import (
     cluster_id_arg,
@@ -297,7 +298,16 @@ command_tree = {
                 ],
                 "resolver": clusters_scale,
             },
-
+            "upgrade": {
+                "help": "Upgrade an existing CrateDB cluster to a later version.",
+                "extra_args": [
+                    lambda req_opt_group, opt_opt_group: cluster_id_arg(
+                        req_opt_group, opt_opt_group, True
+                    ),
+                    crate_version_arg,
+                ],
+                "resolver": clusters_upgrade
+            },
             "delete": {
                 "help": "Delete the specified cluster.",
                 "extra_args": [

--- a/croud/clusters/commands.py
+++ b/croud/clusters/commands.py
@@ -82,6 +82,19 @@ def clusters_scale(args: Namespace) -> None:
     client.print(keys=["id", "name", "num_nodes"])
 
 
+def clusters_upgrade(args: Namespace) -> None:
+    """
+    Upgrade an existing CrateDB Cluster to a later version.
+    """
+
+    body = {"crate_version": args.version}
+    client = Client(env=args.env, region=args.region, output_fmt=args.output_fmt)
+    client.send(
+        RequestMethod.PUT, f"/api/v2/clusters/{args.cluster_id}/upgrade/", body=body
+    )
+    client.print(keys=["id", "name", "crate_version"])
+
+
 @require_confirmation(
     "Are you sure you want to delete the cluster?",
     cancel_msg="Cluster deletion cancelled.",

--- a/docs/commands/clusters.rst
+++ b/docs/commands/clusters.rst
@@ -90,6 +90,29 @@ Example
    | 8d6a7c3c-61d5-11e9-a639-34e12d2331a1 | my-first-crate-cluster |        5 |
    +--------------------------------------+------------------------+----------+
 
+``clusters upgrade``
+====================
+
+.. argparse::
+   :module: croud.__main__
+   :func: get_parser
+   :prog: croud
+   :path: clusters upgrade
+
+Example
+-------
+
+.. code-block:: console
+
+   sh$ croud clusters upgrade \
+       --cluster-id 8d6a7c3c-61d5-11e9-a639-34e12d2331a1 \
+       --version 3.3.3
+   +--------------------------------------+------------------------+---------------+
+   | id                                   | name                   | crate_version |
+   |--------------------------------------+------------------------+---------------|
+   | 8d6a7c3c-61d5-11e9-a639-34e12d2331a1 | my-first-crate-cluster |         3.3.3 |
+   +--------------------------------------+------------------------+---------------+
+
 ``clusters delete``
 ===================
 

--- a/tests/unit_tests/test_commands.py
+++ b/tests/unit_tests/test_commands.py
@@ -246,6 +246,27 @@ class TestClusters(CommandTestCase):
         )
 
     @mock.patch.object(Client, "send")
+    def test_upgrade_cluster(self, mock_send, mock_run, mock_load_config):
+        version = "3.2.6"
+        cluster_id = gen_uuid()
+        argv = [
+            "croud",
+            "clusters",
+            "upgrade",
+            "--cluster-id",
+            cluster_id,
+            "--version",
+            version,
+        ]
+        self.assertRest(
+            mock_send,
+            argv,
+            RequestMethod.PUT,
+            f"/api/v2/clusters/{cluster_id}/upgrade/",
+            body={"crate_version": version},
+        )
+
+    @mock.patch.object(Client, "send")
     def test_clusters_delete(self, mock_send, mock_run, mock_load_config, capsys):
         cluster_id = gen_uuid()
         argv = ["croud", "clusters", "delete", "--cluster-id", cluster_id]


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

* Added `croud clusters upgrade` command to update an existing CrateDB cluster to a later hotfix/patch version.

This PR depends on changes in the backend. https://github.com/crate/cloud-app/pull/815

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed