### PR TITLE
Removed unneeded --project-id argument from clusters scale

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changes for croud
 Unreleased
 ==========
 
+- Removed unneeded ``--project-id`` argument from ``clusters scale`` command.
+
 - Fixed an issue that caused empty query results to print "Success" to
   the console instead of an empty table.
 

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -288,9 +288,6 @@ command_tree = {
             "scale": {
                 "help": "Scale an existing CrateDB cluster.",
                 "extra_args": [
-                    lambda req_opt_group, opt_opt_group: project_id_arg(
-                        req_opt_group, opt_opt_group, True
-                    ),
                     lambda req_opt_group, opt_opt_group: cluster_id_arg(
                         req_opt_group, opt_opt_group, True
                     ),

--- a/croud/clusters/commands.py
+++ b/croud/clusters/commands.py
@@ -74,7 +74,7 @@ def clusters_scale(args: Namespace) -> None:
     Scale an existing CrateDB cluster.
     """
 
-    body = {"project_id": args.project_id, "product_unit": args.unit}
+    body = {"product_unit": args.unit}
     client = Client(env=args.env, region=args.region, output_fmt=args.output_fmt)
     client.send(
         RequestMethod.PUT, f"/api/v2/clusters/{args.cluster_id}/scale/", body=body

--- a/tests/unit_tests/test_commands.py
+++ b/tests/unit_tests/test_commands.py
@@ -225,23 +225,13 @@ class TestClusters(CommandTestCase):
     def test_scale_cluster(self, mock_send, mock_run, mock_load_config):
         unit = 1
         cluster_id = gen_uuid()
-        argv = [
-            "croud",
-            "clusters",
-            "scale",
-            "--project-id",
-            self.project_id,
-            "--cluster-id",
-            cluster_id,
-            "--unit",
-            "1",
-        ]
+        argv = ["croud", "clusters", "scale", "--cluster-id", cluster_id, "--unit", "1"]
         self.assertRest(
             mock_send,
             argv,
             RequestMethod.PUT,
             f"/api/v2/clusters/{cluster_id}/scale/",
-            body={"project_id": self.project_id, "product_unit": unit},
+            body={"product_unit": unit},
         )
 
     @mock.patch.object(Client, "send")


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

The project ID is not required by the back-end to identify a cluster.
The cluster ID is sufficient. The project ID is effectively ignored.


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
