### PR TITLE
Add codecov integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ install:
 script:
   - pytest --cov croud -vvv
 after_success:
-  - pip install coveralls
+  - pip install coveralls codecov
   - coveralls
+  - codecov
 notifications:
   email: false

--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,10 @@ Croud
     :target: https://coveralls.io/github/crate/croud?branch=master
     :alt: Coverage
 
+.. image:: https://codecov.io/gh/crate/croud/branch/master/graph/badge.svg
+    :target: https://codecov.io/gh/crate/croud
+    :alt: Coverage
+
 |
 
 *Croud* is a *command-line interface* (CLI) tool for `CrateDB Cloud`_ ☁.


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This commits changes the .travis.yml so that coverage reports are also
uploaded to codecov.io for analysis.
The status of codecov is displayed as a badge in the README.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
