### PR TITLE
Remove current_context from configuration object

### DIFF
--- a/croud/config.py
+++ b/croud/config.py
@@ -53,8 +53,6 @@ class Configuration:
         "region": "Region",
     }
 
-    current_context: str = ""
-
     @staticmethod
     def validate(config: dict) -> dict:
         schema = Schema(
@@ -98,9 +96,6 @@ class Configuration:
 
     @staticmethod
     def get_env() -> str:
-        if Configuration.current_context:
-            return Configuration.current_context
-
         config = load_config()
         return config["auth"]["current_context"]
 
@@ -115,20 +110,10 @@ class Configuration:
         return get_auth_context().get("token", "")
 
     @staticmethod
-    def set_token(token: str) -> None:
+    def set_token(token: str, env: str) -> None:
         config = load_config()
-
-        context = Configuration.current_context
-        if not context:
-            context = config["auth"]["current_context"]
-
-        config["auth"]["contexts"][context]["token"] = token
-
+        config["auth"]["contexts"][env]["token"] = token
         write_config(config)
-
-    @staticmethod
-    def override_context(env: str) -> None:
-        Configuration.current_context = env
 
 
 def create_default_config() -> None:
@@ -160,12 +145,8 @@ def write_config(config: dict) -> None:
 
 def get_auth_context() -> dict:
     config = load_config()
-
-    context = Configuration.current_context
-    if not context:
-        context = config["auth"]["current_context"]
-
-    return config["auth"]["contexts"][context]
+    env = config["auth"]["current_context"]
+    return config["auth"]["contexts"][env]
 
 
 def config_get(args: Namespace):

--- a/croud/gql.py
+++ b/croud/gql.py
@@ -19,6 +19,7 @@
 
 import asyncio
 from argparse import Namespace
+from functools import partial
 from typing import Dict, Optional
 
 from croud.config import Configuration
@@ -52,7 +53,10 @@ class Query:
 
     async def _fetch_data(self, body: str, variables: Optional[Dict]) -> JsonDict:
         async with HttpSession(
-            self._env, self._token, self._region, on_new_token=Configuration.set_token
+            self._env,
+            self._token,
+            self._region,
+            on_new_token=partial(Configuration.set_token, env=self._env),
         ) as session:
             resp = await session.fetch(
                 RequestMethod.POST,

--- a/croud/login.py
+++ b/croud/login.py
@@ -19,7 +19,7 @@
 
 import asyncio
 from argparse import Namespace
-from typing import Optional
+from functools import partial
 
 from croud.config import Configuration
 from croud.printer import print_error, print_info
@@ -36,12 +36,13 @@ def login(args: Namespace) -> None:
     """
 
     if can_launch_browser():
+        env = args.env or Configuration.get_env()
+
         loop = asyncio.get_event_loop()
         server = Server(loop)
-        server.create_web_app()
+        server.create_web_app(partial(Configuration.set_token, env=env))
         loop.run_until_complete(server.start())
 
-        env = _set_login_env(args.env)
         open_page_in_browser(_login_url(env))
         print_info("A browser tab has been launched for you to login.")
 
@@ -60,12 +61,6 @@ def login(args: Namespace) -> None:
         exit(1)
 
     print_info("Login successful.")
-
-
-def _set_login_env(env: Optional[str]) -> str:
-    env = Configuration.get_env() if env is None else env
-    Configuration.override_context(env)
-    return env
 
 
 def _login_url(env: str) -> str:

--- a/croud/logout.py
+++ b/croud/logout.py
@@ -28,15 +28,12 @@ LOGOUT_PATH = "/oauth2/logout"
 
 
 def logout(args: Namespace) -> None:
-    if args.env is not None:
-        Configuration.override_context(args.env)
-
     loop = asyncio.get_event_loop()
-    env = Configuration.get_env()
+    env = args.env or Configuration.get_env()
     token = Configuration.get_token()
 
     loop.run_until_complete(make_request(env, token))
-    Configuration.set_token("")
+    Configuration.set_token("", env)
 
     print_info("You have been logged out.")
 

--- a/croud/rest.py
+++ b/croud/rest.py
@@ -18,6 +18,7 @@
 # software solely pursuant to the terms of the relevant commercial agreement.
 
 import asyncio
+from functools import partial
 from typing import List, Optional, Union
 
 from aiohttp import ContentTypeError  # type: ignore
@@ -76,7 +77,7 @@ class Client:
             self._env,
             Configuration.get_token(),
             self._region,
-            on_new_token=Configuration.set_token,
+            on_new_token=partial(Configuration.set_token, env=self._env),
         ) as session:
             return await session.fetch(method, endpoint, body, params)
 

--- a/tests/unit_tests/test_authentication.py
+++ b/tests/unit_tests/test_authentication.py
@@ -17,6 +17,7 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+import copy
 from argparse import Namespace
 from typing import Dict
 from unittest import mock
@@ -24,7 +25,7 @@ from unittest import mock
 import pytest
 
 from croud.config import Configuration
-from croud.login import _login_url, _set_login_env, login
+from croud.login import _login_url, login
 from croud.logout import _logout_url, logout
 from croud.server import Server
 
@@ -35,7 +36,7 @@ class MockConfig:
     """
 
     def __init__(self, config: Dict) -> None:
-        self.conf = config
+        self.conf = copy.deepcopy(config)
 
     def read_config(self) -> Dict:
         return self.conf
@@ -134,16 +135,6 @@ class TestLogin:
             "Login only works with a valid browser installed."
         )
         assert e_info.value.code == 1
-
-    @mock.patch("croud.config.Configuration.override_context")
-    @mock.patch("croud.config.Configuration.get_env", return_value="dev")
-    def test_login_env_from_current_context(self, mock_get_env, mock_override_context):
-        env = _set_login_env(None)
-        assert env == "dev"
-
-    def test_login_env_override_context_from_argument(self):
-        env = _set_login_env("prod")
-        assert env == "prod"
 
     def test_login_urls_from_valid_envs(self):
         url = _login_url("dev")

--- a/tests/unit_tests/test_server.py
+++ b/tests/unit_tests/test_server.py
@@ -31,7 +31,7 @@ class TestLocalServer(object):
     def test_token_handler_and_login(self, mock_write_token):
         with loop_context() as loop:
             server = Server(loop)
-            app = server.create_web_app()
+            app = server.create_web_app(on_token=lambda x: None)
             client = TestClient(TestServer(app), loop=loop)
             loop.run_until_complete(client.start_server())
 
@@ -49,7 +49,7 @@ class TestLocalServer(object):
     def test_token_missing_for_login(self, mock_write_token):
         with loop_context() as loop:
             server = Server(loop)
-            app = server.create_web_app()
+            app = server.create_web_app(on_token=lambda x: None)
             client = TestClient(TestServer(app), loop=loop)
             loop.run_until_complete(client.start_server())
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

The Configuration class is responsible for reading from and writing to
the configuration file.
However it was also misused for "temporarily" storing the current
context so it is available across method calls but not persisted to
disk.
This PR removes the current_context property from the class.