### PR TITLE
Revert "fix erroneous line"

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -10,3 +10,4 @@ alabaster>=0.7,<0.8,!=0.7.5
 setuptools<41
 sphinx==1.7.4
 sphinx-argparse==0.2.5
+.


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This reverts commit 2d62c68ec12be8eff9efd9aaba796ac018907340.

The `.` in the `requirements-docs.txt` is required so that the `croud`
project itself is also installed into the virtualenv when running

```console
$ env/bin/pip install -e requirements-docs.txt
```

Otherwise the `bin/spinx` command would error with following message if
the project had not been installed into the virtualenv before with
`env/bin/pip install -e .`:

```console
Warning, treated as error:
/home/christian/sandbox/crate/croud/docs/commands/authentication.rst:17:Failed to import "get_parser" from "croud.__main__".
No module named 'croud'
```