### PR TITLE
improved printing of error messages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for croud
 Unreleased
 ==========
 
+- Improved printing of error messages by including the error details returned
+  by the server.
+
 0.14.0 - 2019/06/06
 ===================
 

--- a/croud/rest.py
+++ b/croud/rest.py
@@ -102,6 +102,8 @@ class Client:
         if self._error:
             if "message" in self._error:
                 print_error(self._error["message"])
+                if "errors" in self._error:
+                    print_format(self._error["errors"], "json")
             else:
                 print_format(self._error, "json")
             return

--- a/tests/unit_tests/test_rest.py
+++ b/tests/unit_tests/test_rest.py
@@ -112,14 +112,15 @@ def test_print_success(mock_print_format, mock_print_success, event_loop):
     )
 
 
-@mock.patch("croud.rest.print_error")
-def test_print_error(mock_print_error, event_loop):
+def test_print_error(capsys, event_loop):
     client = Client(env="dev", region="bregenz.a1", output_fmt="json", loop=event_loop)
 
     error = {"message": "Bad request.", "errors": {"key": "Error on 'key'"}}
     client._error = error
     client.print()
-    mock_print_error.assert_called_once_with("Bad request.")
+    captured = capsys.readouterr()
+    assert "Bad request." in captured.out
+    assert '"key": "Error on \'key\'"' in captured.out
 
 
 @mock.patch("croud.rest.print_format")


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

the `errors` part of an error message was not printed, when the error contained a `message`.
this caused the schema validation error to be incomprehensible. 

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
