### PR TITLE
Update croud cluster deploy command example

### DIFF
--- a/docs/commands/clusters.rst
+++ b/docs/commands/clusters.rst
@@ -55,7 +55,7 @@ Example
    sh$ croud clusters deploy \
        --product-name cratedb.az1 \
        --tier xs \
-       --name my-first-crate-cluster \
+       --cluster-name my-first-crate-cluster \
        --project-id 952cd102-91c1-4837-962a-12ecb71a6ba8 \
        --version 3.2.6 \
        --username default \


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
The example command in the documentation is showing the wrong parameter
`name`, which is not valid. Updated the documentation to show the actual
parameter `cluster-name`.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
