### PR TITLE
Updated users roles list command to use REST instead of GraphQL

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changes for croud
 Unreleased
 ==========
 
+- Updated ``users roles list`` command to use the REST endpoint instead of GraphQL.
+
 - [Breaking] The ``organizations users add|remove`` commands now require the arguments
   ``--user`` and ``--org-id``. Additionally the ``organizations users add`` command
   requires the ``--role`` argument.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,6 @@ Changes for croud
 Unreleased
 ==========
 
-- Updated ``users roles list`` command to use the REST endpoint instead of GraphQL.
-
 - [Breaking] The ``organizations users add|remove`` commands now require the arguments
   ``--user`` and ``--org-id``. Additionally the ``organizations users add`` command
   requires the ``--role`` argument.

--- a/croud/users/roles/commands.py
+++ b/croud/users/roles/commands.py
@@ -21,6 +21,8 @@ import textwrap
 from argparse import Namespace
 
 from croud.gql import Query, print_query
+from croud.rest import Client
+from croud.session import RequestMethod
 from croud.util import clean_dict
 
 
@@ -59,22 +61,9 @@ def roles_list(args: Namespace) -> None:
     Lists all roles a user can be assigned to
     """
 
-    _query = textwrap.dedent(
-        """
-        query {
-            allRoles {
-                data {
-                    fqn
-                    friendlyName
-                }
-            }
-        }
-    """
-    ).strip()
-
-    query = Query(_query, args)
-    query.execute()
-    print_query(query, "allRoles")
+    client = Client(env=args.env, region=args.region, output_fmt=args.output_fmt)
+    client.send(RequestMethod.GET, "/api/v2/roles/")
+    client.print(keys=["id", "name"])
 
 
 def roles_remove(args: Namespace) -> None:

--- a/docs/commands/users.rst
+++ b/docs/commands/users.rst
@@ -48,6 +48,21 @@ Example
 
    See :ref:`roles` for more information about the different roles.
 
+Example
+-------
+
+.. code-block:: console
+
+   sh$ croud users roles list
+   +----------------+---------------------+
+   | id             | name                |
+   |----------------+---------------------|
+   | org_admin      | Organization Admin  |
+   | org_member     | Organization Member |
+   | project_admin  | Project Admin       |
+   | project_member | Project Member      |
+   +----------------+---------------------+
+
 
 ``users roles add``
 -------------------

--- a/tests/unit_tests/test_commands.py
+++ b/tests/unit_tests/test_commands.py
@@ -534,22 +534,14 @@ class TestUsersRoles(CommandTestCase):
         ]
         self.assertGql(mock_run, argv, expected_body, expected_vars)
 
-    def test_list(self, mock_run, mock_load_config):
-        expected_body = textwrap.dedent(
-            """
-        query {
-            allRoles {
-                data {
-                    fqn
-                    friendlyName
-                }
-            }
-        }
-    """
-        ).strip()
 
+@mock.patch("croud.config.load_config", return_value=Configuration.DEFAULT_CONFIG)
+@mock.patch.object(Client, "send")
+class TestUsersRolesREST(CommandTestCase):
+    def test_list(self, mock_send, mock_load_config):
         argv = ["croud", "users", "roles", "list"]
-        self.assertGql(mock_run, argv, expected_body)
+
+        self.assertRest(mock_send, argv, RequestMethod.GET, "/api/v2/roles/")
 
 
 @mock.patch("croud.config.load_config", return_value=Configuration.DEFAULT_CONFIG)


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

- Updated users roles list command to use REST instead of GraphQL.

This PR depends on changes in the backend. https://github.com/crate/cloud-app/pull/827

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed