### PR TITLE
Updated the user_id parameter to user in org_users_add

### DIFF
--- a/croud/organizations/users/commands.py
+++ b/croud/organizations/users/commands.py
@@ -32,7 +32,7 @@ def org_users_add(args: Namespace):
     client.send(
         RequestMethod.POST,
         f"/api/v2/organizations/{args.org_id}/users/",
-        body={"user_id": args.user, "role_fqn": args.role},
+        body={"user": args.user, "role_fqn": args.role},
     )
     client.print(keys=["user_id", "role_fqn", "organization_id"])
 

--- a/tests/unit_tests/test_commands.py
+++ b/tests/unit_tests/test_commands.py
@@ -417,7 +417,7 @@ class TestOrganizations(CommandTestCase):
             argv,
             RequestMethod.POST,
             f"/api/v2/organizations/{org_id}/users/",
-            body={"user_id": user, "role_fqn": role_fqn},
+            body={"user": user, "role_fqn": role_fqn},
         )
 
     def test_remove_user(self, mock_send, mock_load_config):


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

The user_id parameter that was used to add a org_role to a user no longer reflects that it can be a user-id or a email address. Moving forward the parameter will be user.

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
