### PR TITLE
Add command to delete an existing organization

### DIFF
--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -72,7 +72,11 @@ from croud.login import login
 from croud.logout import logout
 from croud.me import me
 from croud.monitoring.grafana.commands import set_grafana
-from croud.organizations.commands import organizations_create, organizations_list
+from croud.organizations.commands import (
+    organizations_create,
+    organizations_delete,
+    organizations_list,
+)
 from croud.organizations.users.commands import org_users_add, org_users_remove
 from croud.parser import create_parser
 from croud.products.commands import products_list
@@ -342,6 +346,16 @@ command_tree = {
                 "help": "List all organizations the current user has access to.",
                 "extra_args": [],
                 "resolver": organizations_list,
+            },
+            "delete": {
+                "help": "Delete the specified organization.",
+                "extra_args": [
+                    yes_arg,
+                    lambda req_opt_group, opt_opt_group: org_id_arg(
+                        req_opt_group, opt_opt_group, True
+                    ),
+                ],
+                "resolver": organizations_delete,
             },
             "users": {
                 "help": "Manage users in an organization.",

--- a/croud/organizations/commands.py
+++ b/croud/organizations/commands.py
@@ -21,6 +21,7 @@ from argparse import Namespace
 
 from croud.rest import Client
 from croud.session import RequestMethod
+from croud.util import require_confirmation
 
 
 def organizations_create(args: Namespace) -> None:
@@ -45,3 +46,17 @@ def organizations_list(args: Namespace) -> None:
     client = Client(env=args.env, output_fmt=args.output_fmt)
     client.send(RequestMethod.GET, "/api/v2/organizations/")
     client.print(keys=["id", "name", "plan_type"])
+
+
+@require_confirmation(
+    "Are you sure you want to delete the organization?",
+    cancel_msg="Organization deletion cancelled.",
+)
+def organizations_delete(args: Namespace) -> None:
+    """
+    Delete an organization
+    """
+
+    client = Client(env=args.env, output_fmt=args.output_fmt)
+    client.send(RequestMethod.DELETE, f"/api/v2/organizations/{args.org_id}/")
+    client.print("Organization deleted.")

--- a/docs/commands/organizations.rst
+++ b/docs/commands/organizations.rst
@@ -62,6 +62,26 @@ Example
    +--------------------------------------+--------+------------+
 
 
+``organizations delete``
+========================
+
+.. argparse::
+   :module: croud.__main__
+   :func: get_parser
+   :prog: croud
+   :path: organizations delete
+
+Example
+-------
+
+.. code-block:: console
+
+   sh$ croud organizations delete \
+       --org-id f6c39580-5719-431d-a508-0cee4f9e8209
+   Are you sure you want to delete the consumer? [yN] y
+   ==> Success: Organization deleted.
+
+
 ``organizations users``
 =======================
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

The command for deleting an organization is `croud organizations delete
--org-id <id>`.

```console
$ croud organizations delete
The following arguments are required: --org-id

Usage: croud organizations delete [-h] [-y] --org-id ORG_ID
                                  [--region {bregenz.a1,westeurope.azure,eastus2.azure,eastus.azure}]
                                  [--env {local,prod,dev}]
                                  [--output-fmt {json,table}]

Required Arguments:
  --org-id ORG_ID       The organization ID to use.

Optional Arguments:
  -h, --help            Show this help message and exit.
  -y, --yes
  --region {bregenz.a1,westeurope.azure,eastus2.azure,eastus.azure}, -r {bregenz.a1,westeurope.azure,eastus2.azure,eastus.azure}
                        Temporarily use the specified region that command will
                        be run in.
  --env {local,prod,dev}, -e {local,prod,dev}
                        Switches auth context.
  --output-fmt {json,table}, -o {json,table}
                        Change the formatting of the output
```

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
