### PR TITLE
Added command to delete projects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changes for croud
 Unreleased
 ==========
 
+- Added ``projects delete`` command to delete existing projects.
+
 - Added ``organizations delete`` command to delete existing organizations.
 
 - Fixed a bug that caused commands to always use the access token from the

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -80,7 +80,7 @@ from croud.organizations.commands import (
 from croud.organizations.users.commands import org_users_add, org_users_remove
 from croud.parser import create_parser
 from croud.products.commands import products_list
-from croud.projects.commands import project_create, projects_list
+from croud.projects.commands import project_create, project_delete, projects_list
 from croud.projects.users.commands import project_user_add, project_user_remove
 from croud.users.commands import users_list
 from croud.users.roles.commands import roles_add, roles_list, roles_remove
@@ -220,6 +220,16 @@ command_tree = {
                     ),
                 ],
                 "resolver": project_create,
+            },
+            "delete": {
+                "help": "Delete the specified project.",
+                "extra_args": [
+                    lambda req_opt_group, opt_opt_group: project_id_arg(
+                        req_opt_group, opt_opt_group, True
+                    ),
+                    yes_arg,
+                ],
+                "resolver": project_delete,
             },
             "list": {
                 "help": (

--- a/croud/projects/commands.py
+++ b/croud/projects/commands.py
@@ -21,6 +21,7 @@ from argparse import Namespace
 
 from croud.rest import Client
 from croud.session import RequestMethod
+from croud.util import require_confirmation
 
 
 def project_create(args: Namespace) -> None:
@@ -35,6 +36,19 @@ def project_create(args: Namespace) -> None:
         body={"name": args.name, "organization_id": args.org_id},
     )
     client.print(keys=["id"])
+
+
+@require_confirmation(
+    "Are you sure you want to delete the project?",
+    cancel_msg="Project deletion cancelled.",
+)
+def project_delete(args: Namespace) -> None:
+    """
+    Deletes a project in the organization the user belongs to.
+    """
+    client = Client.from_args(args)
+    client.send(RequestMethod.DELETE, f"/api/v2/projects/{args.project_id}/")
+    client.print("Project deleted.")
 
 
 def projects_list(args: Namespace) -> None:

--- a/croud/users/roles/commands.py
+++ b/croud/users/roles/commands.py
@@ -61,7 +61,7 @@ def roles_list(args: Namespace) -> None:
     Lists all roles a user can be assigned to
     """
 
-    client = Client(env=args.env, region=args.region, output_fmt=args.output_fmt)
+    client = Client.from_args(args)
     client.send(RequestMethod.GET, "/api/v2/roles/")
     client.print(keys=["id", "name"])
 

--- a/docs/commands/projects.rst
+++ b/docs/commands/projects.rst
@@ -34,6 +34,25 @@ Example
    +--------------------------------------+
 
 
+``projects delete``
+===================
+
+.. argparse::
+   :module: croud.__main__
+   :func: get_parser
+   :prog: croud
+   :path: projects delete
+
+Example
+-------
+
+.. code-block:: console
+
+   sh$ croud projects delete --project-id 035f1161-402e-44b4-9073-0749586091e0
+   Are you sure you want to delete the project? [yN] y
+   ==> Success: Project deleted.
+
+
 ``projects list``
 =================
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

```
$ croud projects delete --help                                           
Usage: croud projects delete [-h] -p PROJECT_ID [-y]
                             [--region {eastus2.azure,eastus.azure,bregenz.a1,westeurope.azure}]
                             [--env {dev,prod,local}]
                             [--output-fmt {json,table}]

Required Arguments:
  -p PROJECT_ID, --project-id PROJECT_ID
                        The project ID to use.

Optional Arguments:
  -h, --help            Show this help message and exit.
  -y, --yes
  --region {eastus2.azure,eastus.azure,bregenz.a1,westeurope.azure}, -r {eastus2.azure,eastus.azure,bregenz.a1,westeurope.azure}
                        Temporarily use the specified region that command will
                        be run in.
  --env {dev,prod,local}, -e {dev,prod,local}
                        Switches auth context.
  --output-fmt {json,table}, -o {json,table}
                        Change the formatting of the output
```

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
