### PR TITLE
Added the argument channel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for croud
 Unreleased
 ==========
 
+- Add the ``channel`` argument to the cluster deploy command. This is needed 
+  to be able to specify either a stable, testing or nightly version.
+
 - Deprecated ``croud users roles add`` and ``croud users roles remove`` in
   favor of project and organization level commands ``croud
   organizations|projects users add|remove``.

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -31,6 +31,7 @@ from croud.clusters.commands import (
     clusters_upgrade,
 )
 from croud.cmd import (
+    channel_arg,
     cluster_id_arg,
     cluster_name_arg,
     consumer_id_arg,
@@ -300,6 +301,9 @@ command_tree = {
                     crate_version_arg,
                     crate_username_arg,
                     crate_password_arg,
+                    lambda req_opt_group, opt_opt_group: channel_arg(
+                        req_opt_group, opt_opt_group, False
+                    ),
                 ],
                 "resolver": clusters_deploy,
             },

--- a/croud/clusters/commands.py
+++ b/croud/clusters/commands.py
@@ -44,6 +44,7 @@ def clusters_list(args: Namespace) -> None:
             "project_id",
             "username",
             "fqdn",
+            "channel",
         ]
     )
 
@@ -61,6 +62,7 @@ def clusters_deploy(args: Namespace) -> None:
         "product_tier": args.tier,
         "project_id": args.project_id,
         "username": args.username,
+        "channel": args.channel,
     }
     if args.unit:
         body["product_unit"] = args.unit

--- a/croud/cmd.py
+++ b/croud/cmd.py
@@ -289,3 +289,16 @@ def num_instances_arg(req_args: _ArgumentGroup, opt_args: _ArgumentGroup) -> Non
 
 def kind_arg(req_args: _ArgumentGroup, opt_args: _ArgumentGroup) -> None:
     opt_args.add_argument("--kind", type=str, help="The product kind.", required=False)
+
+
+def channel_arg(
+    req_args: _ArgumentGroup, opt_args: _ArgumentGroup, required: bool = True
+) -> None:
+    group = req_args if required else opt_args
+    group.add_argument(
+        "--channel",
+        type=str,
+        help="The channel of the CrateDB version.",
+        default="stable",
+        required=False,
+    )

--- a/tests/unit_tests/test_commands.py
+++ b/tests/unit_tests/test_commands.py
@@ -192,6 +192,7 @@ class TestClusters(CommandTestCase):
                 "product_unit": 1,
                 "project_id": self.project_id,
                 "username": "foobar",
+                "channel": "stable",
             },
         )
 
@@ -229,6 +230,50 @@ class TestClusters(CommandTestCase):
                 "product_tier": "xs",
                 "project_id": self.project_id,
                 "username": "foobar",
+                "channel": "stable",
+            },
+        )
+
+    @mock.patch.object(Client, "send")
+    def test_deploy_cluster_nightly(self, mock_send, mock_run, mock_load_config):
+        argv = [
+            "croud",
+            "clusters",
+            "deploy",
+            "--product-name",
+            "cratedb.az1",
+            "--tier",
+            "xs",
+            "--unit",
+            "1",
+            "--project-id",
+            self.project_id,
+            "--cluster-name",
+            "crate_cluster",
+            "--version",
+            "nightly",
+            "--username",
+            "foobar",
+            "--password",
+            "s3cr3t!",
+            "--channel",
+            "nightly",
+        ]
+        self.assertRest(
+            mock_send,
+            argv,
+            RequestMethod.POST,
+            "/api/v2/clusters/",
+            body={
+                "crate_version": "nightly",
+                "name": "crate_cluster",
+                "password": "s3cr3t!",
+                "product_name": "cratedb.az1",
+                "product_tier": "xs",
+                "project_id": self.project_id,
+                "username": "foobar",
+                "channel": "nightly",
+                "product_unit": 1,
             },
         )
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
The arguments channel and registry are needed to be able to specify if
the version should be a stable/testing/nightly, as well as the required
registry for the image, e.g. crate/crate for nightly and testing.

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
