### PR TITLE
Add support for YAML output

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for croud
 Unreleased
 ==========
 
+- Added support for YAML output. It can be specified with the ``-o yaml``
+  argument.
+
 0.16.0 - 2019/07/18
 ===================
 

--- a/croud/parser.py
+++ b/croud/parser.py
@@ -108,7 +108,7 @@ def add_default_args(parser):
         "--output-fmt",
         "-o",
         required=False,
-        choices={"table", "json"},
+        choices={"table", "json", "yaml"},
         help="Change the formatting of the output",
     )
 

--- a/croud/printer.py
+++ b/croud/printer.py
@@ -22,6 +22,7 @@ import functools
 import json
 from typing import Dict, List, Optional, Type, Union
 
+import yaml
 from colorama import Fore, Style
 from tabulate import tabulate
 
@@ -121,7 +122,13 @@ class TableFormatPrinter(FormatPrinter):
             return field
 
 
-PRINTERS: Dict[str, Union[Type[JsonFormatPrinter], Type[TableFormatPrinter]]] = {
+class YamlFormatPrinter(FormatPrinter):
+    def format_rows(self, rows: Union[List[JsonDict], JsonDict]) -> str:
+        return yaml.dump(rows, default_flow_style=False)
+
+
+PRINTERS: Dict[str, Type[FormatPrinter]] = {
     "json": JsonFormatPrinter,
     "table": TableFormatPrinter,
+    "yaml": YamlFormatPrinter,
 }

--- a/tests/unit_tests/test_printer.py
+++ b/tests/unit_tests/test_printer.py
@@ -19,7 +19,7 @@
 
 import pytest
 
-from croud.printer import JsonFormatPrinter, TableFormatPrinter
+from croud.printer import JsonFormatPrinter, TableFormatPrinter, YamlFormatPrinter
 
 
 @pytest.mark.parametrize(
@@ -46,6 +46,30 @@ from croud.printer import JsonFormatPrinter, TableFormatPrinter
 )
 def test_json_format(rows, expected):
     out = JsonFormatPrinter().format_rows(rows)
+    assert out == expected
+
+
+@pytest.mark.parametrize(
+    "rows,expected",
+    (
+        (None, "null\n...\n"),
+        ({}, "{}\n"),
+        (
+            {"a": "foo : bar", "b": 1, "c": True, "d": {"x": 1, "y": None, "z": False}},
+            (
+                "a: 'foo : bar'\n"
+                "b: 1\n"
+                "c: true\n"
+                "d:\n"
+                "  x: 1\n"
+                "  y: null\n"
+                "  z: false\n"
+            ),
+        ),
+    ),
+)
+def test_yaml_format(rows, expected):
+    out = YamlFormatPrinter().format_rows(rows)
     assert out == expected
 
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

The output format can be changed to YAML using the `-o yaml` argument.


## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
