### PR TITLE
Reworked REST client and printing

### DIFF
--- a/croud/clusters/commands.py
+++ b/croud/clusters/commands.py
@@ -19,6 +19,8 @@
 
 from argparse import Namespace
 
+from croud.config import get_output_format
+from croud.printer import print_response
 from croud.rest import Client
 from croud.session import RequestMethod
 from croud.util import require_confirmation
@@ -34,8 +36,10 @@ def clusters_list(args: Namespace) -> None:
         params["project_id"] = args.project_id
 
     client = Client.from_args(args)
-    client.send(RequestMethod.GET, "/api/v2/clusters/", params=params)
-    client.print(
+    data, errors = client.send(RequestMethod.GET, "/api/v2/clusters/", params=params)
+    print_response(
+        data=data,
+        errors=errors,
         keys=[
             "id",
             "name",
@@ -45,7 +49,8 @@ def clusters_list(args: Namespace) -> None:
             "username",
             "fqdn",
             "channel",
-        ]
+        ],
+        output_fmt=get_output_format(args),
     )
 
 
@@ -67,8 +72,16 @@ def clusters_deploy(args: Namespace) -> None:
     if args.unit:
         body["product_unit"] = args.unit
     client = Client.from_args(args)
-    client.send(RequestMethod.POST, "/api/v2/clusters/", body=body)
-    client.print(keys=["id", "name", "fqdn", "url"])
+    data, errors = client.send(RequestMethod.POST, "/api/v2/clusters/", body=body)
+    print_response(
+        data=data,
+        errors=errors,
+        keys=["id", "name", "fqdn", "url"],
+        success_message=(
+            "Cluster deployed. It may take a few minutes to complete the changes."
+        ),
+        output_fmt=get_output_format(args),
+    )
 
 
 def clusters_scale(args: Namespace) -> None:
@@ -78,10 +91,18 @@ def clusters_scale(args: Namespace) -> None:
 
     body = {"product_unit": args.unit}
     client = Client.from_args(args)
-    client.send(
+    data, errors = client.send(
         RequestMethod.PUT, f"/api/v2/clusters/{args.cluster_id}/scale/", body=body
     )
-    client.print(keys=["id", "name", "num_nodes"])
+    print_response(
+        data=data,
+        errors=errors,
+        keys=["id", "name", "num_nodes"],
+        success_message=(
+            "Cluster scaled. It may take a few minutes to complete the changes."
+        ),
+        output_fmt=get_output_format(args),
+    )
 
 
 def clusters_upgrade(args: Namespace) -> None:
@@ -91,10 +112,18 @@ def clusters_upgrade(args: Namespace) -> None:
 
     body = {"crate_version": args.version}
     client = Client.from_args(args)
-    client.send(
+    data, errors = client.send(
         RequestMethod.PUT, f"/api/v2/clusters/{args.cluster_id}/upgrade/", body=body
     )
-    client.print(keys=["id", "name", "crate_version"])
+    print_response(
+        data=data,
+        errors=errors,
+        keys=["id", "name", "num_nodes"],
+        success_message=(
+            "Cluster upgraded. It may take a few minutes to complete the changes."
+        ),
+        output_fmt=get_output_format(args),
+    )
 
 
 @require_confirmation(
@@ -103,5 +132,12 @@ def clusters_upgrade(args: Namespace) -> None:
 )
 def clusters_delete(args: Namespace) -> None:
     client = Client.from_args(args)
-    client.send(RequestMethod.DELETE, f"/api/v2/clusters/{args.cluster_id}/")
-    client.print("Cluster deleted.")
+    data, errors = client.send(
+        RequestMethod.DELETE, f"/api/v2/clusters/{args.cluster_id}/"
+    )
+    print_response(
+        data=data,
+        errors=errors,
+        success_message="Cluster deleted.",
+        output_fmt=get_output_format(args),
+    )

--- a/croud/config.py
+++ b/croud/config.py
@@ -186,3 +186,14 @@ def config_set(args: Namespace, parser=None):
             else:
                 set_property(key, setting)
                 print_info(f"{Configuration.CONFIG_NAMES[key]} switched to {setting}")
+
+
+def get_output_format(args: Namespace) -> str:
+    """
+    Gets the default output_format
+    """
+    return (
+        args.output_fmt
+        if args.output_fmt is not None
+        else Configuration.get_setting("output_fmt")
+    )

--- a/croud/consumers/commands.py
+++ b/croud/consumers/commands.py
@@ -19,6 +19,8 @@
 
 from argparse import Namespace
 
+from croud.config import get_output_format
+from croud.printer import print_response
 from croud.rest import Client
 from croud.session import RequestMethod
 from croud.util import require_confirmation
@@ -42,8 +44,10 @@ def consumers_deploy(args: Namespace) -> None:
         "table_schema": args.consumer_schema,
     }
     client = Client.from_args(args)
-    client.send(RequestMethod.POST, "/api/v2/consumers/", body=body)
-    client.print(
+    data, errors = client.send(RequestMethod.POST, "/api/v2/consumers/", body=body)
+    print_response(
+        data=data,
+        errors=errors,
         keys=[
             "cluster_id",
             "id",
@@ -54,7 +58,11 @@ def consumers_deploy(args: Namespace) -> None:
             "project_id",
             "table_name",
             "table_schema",
-        ]
+        ],
+        success_message=(
+            "Consumer deployed. It may take a few minutes to complete the changes."
+        ),
+        output_fmt=get_output_format(args),
     )
 
 
@@ -68,8 +76,10 @@ def consumers_list(args: Namespace) -> None:
         params["project_id"] = args.project_id
 
     client = Client.from_args(args)
-    client.send(RequestMethod.GET, "/api/v2/consumers/", params=params)
-    client.print(
+    data, errors = client.send(RequestMethod.GET, "/api/v2/consumers/", params=params)
+    print_response(
+        data=data,
+        errors=errors,
         keys=[
             "cluster_id",
             "id",
@@ -80,7 +90,8 @@ def consumers_list(args: Namespace) -> None:
             "project_id",
             "table_name",
             "table_schema",
-        ]
+        ],
+        output_fmt=get_output_format(args),
     )
 
 
@@ -103,10 +114,12 @@ def consumers_edit(args: Namespace) -> None:
     if config:
         body["config"] = config
     client = Client.from_args(args)
-    client.send(
+    data, errors = client.send(
         RequestMethod.PATCH, f"/api/v2/consumers/{args.consumer_id}/", body=body
     )
-    client.print(keys=["id"])
+    print_response(
+        data=data, errors=errors, keys=["id"], output_fmt=get_output_format(args)
+    )
 
 
 @require_confirmation(
@@ -115,5 +128,12 @@ def consumers_edit(args: Namespace) -> None:
 )
 def consumers_delete(args: Namespace) -> None:
     client = Client.from_args(args)
-    client.send(RequestMethod.DELETE, f"/api/v2/consumers/{args.consumer_id}/")
-    client.print("Consumer deleted.")
+    data, errors = client.send(
+        RequestMethod.DELETE, f"/api/v2/consumers/{args.consumer_id}/"
+    )
+    print_response(
+        data=data,
+        errors=errors,
+        success_message="Consumer deleted.",
+        output_fmt=get_output_format(args),
+    )

--- a/croud/login.py
+++ b/croud/login.py
@@ -38,9 +38,8 @@ def get_org_id() -> Optional[str]:
         Configuration.get_setting("region"),
         Configuration.get_setting("output-fmt"),
     )
-    client.send(RequestMethod.GET, "/api/v2/users/me/")
-    if client._data and not client._error:
-        data: dict = client._data  # type: ignore
+    data, error = client.send(RequestMethod.GET, "/api/v2/users/me/")
+    if data and not error:
         if not data.get("is_superuser") and "organization_id" in data:
             return data.get("organization_id")
     return None

--- a/croud/me.py
+++ b/croud/me.py
@@ -19,6 +19,8 @@
 
 from argparse import Namespace
 
+from croud.config import get_output_format
+from croud.printer import print_response
 from croud.rest import Client
 from croud.session import RequestMethod
 
@@ -29,5 +31,10 @@ def me(args: Namespace) -> None:
     """
 
     client = Client.from_args(args)
-    client.send(RequestMethod.GET, "/api/v2/users/me/")
-    client.print(keys=["email", "username"])
+    data, errors = client.send(RequestMethod.GET, "/api/v2/users/me/")
+    print_response(
+        data=data,
+        errors=errors,
+        keys=["email", "username"],
+        output_fmt=get_output_format(args),
+    )

--- a/croud/monitoring/grafana/commands.py
+++ b/croud/monitoring/grafana/commands.py
@@ -19,6 +19,8 @@
 
 from argparse import Namespace
 
+from croud.config import get_output_format
+from croud.printer import print_response
 from croud.rest import Client
 from croud.session import RequestMethod
 
@@ -27,7 +29,13 @@ def set_grafana(enable: bool, args: Namespace) -> None:
     method = RequestMethod.POST if enable else RequestMethod.DELETE
 
     client = Client.from_args(args)
-    client.send(
+    data, errors = client.send(
         method, "/api/v2/monitoring/grafana/", body={"project_id": args.project_id}
     )
-    client.print()
+    state = "enabled" if enable else "disabled"
+    print_response(
+        data=data,
+        errors=errors,
+        success_message=f"Grafana {state}.",
+        output_fmt=get_output_format(args),
+    )

--- a/croud/organizations/commands.py
+++ b/croud/organizations/commands.py
@@ -19,7 +19,8 @@
 
 from argparse import Namespace
 
-from croud.config import Configuration
+from croud.config import Configuration, get_output_format
+from croud.printer import print_response
 from croud.rest import Client
 from croud.session import RequestMethod
 from croud.util import org_id_config_fallback, require_confirmation
@@ -31,12 +32,18 @@ def organizations_create(args: Namespace) -> None:
     """
 
     client = Client.from_args(args)
-    client.send(
+    data, errors = client.send(
         RequestMethod.POST,
         "/api/v2/organizations/",
         body={"name": args.name, "plan_type": args.plan_type},
     )
-    client.print(keys=["id", "name", "plan_type"])
+    print_response(
+        data=data,
+        errors=errors,
+        keys=["id", "name", "plan_type"],
+        success_message="Organization created.",
+        output_fmt=get_output_format(args),
+    )
 
 
 def organizations_list(args: Namespace) -> None:
@@ -45,8 +52,13 @@ def organizations_list(args: Namespace) -> None:
     """
 
     client = Client.from_args(args)
-    client.send(RequestMethod.GET, "/api/v2/organizations/")
-    client.print(keys=["id", "name", "plan_type"])
+    data, errors = client.send(RequestMethod.GET, "/api/v2/organizations/")
+    print_response(
+        data=data,
+        errors=errors,
+        keys=["id", "name", "plan_type"],
+        output_fmt=get_output_format(args),
+    )
 
 
 @org_id_config_fallback
@@ -60,8 +72,15 @@ def organizations_delete(args: Namespace) -> None:
     """
 
     client = Client.from_args(args)
-    client.send(RequestMethod.DELETE, f"/api/v2/organizations/{args.org_id}/")
-    client.print("Organization deleted.")
+    data, errors = client.send(
+        RequestMethod.DELETE, f"/api/v2/organizations/{args.org_id}/"
+    )
+    print_response(
+        data=data,
+        errors=errors,
+        success_message="Organization deleted.",
+        output_fmt=get_output_format(args),
+    )
 
     env = args.env or Configuration.get_env()
     config_org_id = Configuration.get_organization_id(env)

--- a/croud/organizations/users/commands.py
+++ b/croud/organizations/users/commands.py
@@ -22,6 +22,8 @@
 
 from argparse import Namespace
 
+from croud.config import get_output_format
+from croud.printer import print_response
 from croud.rest import Client
 from croud.session import RequestMethod
 from croud.util import org_id_config_fallback
@@ -31,19 +33,35 @@ from croud.util import org_id_config_fallback
 def org_users_add(args: Namespace):
     client = Client.from_args(args)
 
-    client.send(
+    data, errors = client.send(
         RequestMethod.POST,
         f"/api/v2/organizations/{args.org_id}/users/",
         body={"user": args.user, "role_fqn": args.role},
     )
-    client.print(keys=["user_id", "role_fqn", "organization_id"])
+    if data is not None and data.get("added", False):
+        success_message = "User added to organization."
+    else:
+        success_message = "Role altered for user."
+
+    print_response(
+        data=data,
+        errors=errors,
+        keys=["user_id", "organization_id", "role_fqn"],
+        success_message=success_message,
+        output_fmt=get_output_format(args),
+    )
 
 
 @org_id_config_fallback
 def org_users_remove(args: Namespace):
     client = Client.from_args(args)
 
-    client.send(
+    data, errors = client.send(
         RequestMethod.DELETE, f"/api/v2/organizations/{args.org_id}/users/{args.user}/"
     )
-    client.print(success_message="Successfully removed user from organization.")
+    print_response(
+        data=data,
+        errors=errors,
+        success_message="User removed from organization.",
+        output_fmt=get_output_format(args),
+    )

--- a/croud/printer.py
+++ b/croud/printer.py
@@ -20,6 +20,7 @@
 import abc
 import functools
 import json
+import sys
 from typing import Dict, List, Optional, Type, Union
 
 import yaml
@@ -27,6 +28,8 @@ from colorama import Fore, Style
 from tabulate import tabulate
 
 from croud.typing import JsonDict
+
+print_stderr = functools.partial(print, file=sys.stderr)
 
 
 def print_format(
@@ -41,20 +44,46 @@ def print_format(
     printer.print_rows(rows)
 
 
+def print_response(
+    data, errors, output_fmt, success_message: str = None, keys: List[str] = None
+):
+    if errors:
+        if "message" in errors:
+            print_error(errors["message"])
+            if "errors" in errors:
+                print_format(errors["errors"], "json")
+        else:
+            print_format(errors, "json")
+        return
+
+    if data is None:
+        message = success_message or "Success."
+        print_success(message)
+        return
+
+    print_format(data, output_fmt, keys)
+
+    if data and success_message is not None:
+        message = success_message
+        print_success(message)
+
+
 def print_error(text: str):
-    print(Fore.RED + "==> Error: " + Style.RESET_ALL + text)
+    print_stderr(Fore.RED + "==> Error: " + Style.RESET_ALL + text, file=sys.stderr)
 
 
 def print_info(text: str):
-    print(Fore.CYAN + "==> Info: " + Style.RESET_ALL + text)
+    print_stderr(Fore.CYAN + "==> Info: " + Style.RESET_ALL + text, file=sys.stderr)
 
 
 def print_warning(text: str):
-    print(Fore.YELLOW + "==> Warning: " + Style.RESET_ALL + text)
+    print_stderr(
+        Fore.YELLOW + "==> Warning: " + Style.RESET_ALL + text, file=sys.stderr
+    )
 
 
 def print_success(text: str):
-    print(Fore.GREEN + "==> Success: " + Style.RESET_ALL + text)
+    print_stderr(Fore.GREEN + "==> Success: " + Style.RESET_ALL + text, file=sys.stderr)
 
 
 class FormatPrinter(abc.ABC):

--- a/croud/products/commands.py
+++ b/croud/products/commands.py
@@ -19,6 +19,8 @@
 
 from argparse import Namespace
 
+from croud.config import get_output_format
+from croud.printer import print_response
 from croud.rest import Client
 from croud.session import RequestMethod
 
@@ -31,7 +33,12 @@ def products_list(args: Namespace) -> None:
     client = Client.from_args(args)
     url = "/api/v2/products/"
     if args.kind:
-        client.send(RequestMethod.GET, url, params={"kind": args.kind})
+        data, errors = client.send(RequestMethod.GET, url, params={"kind": args.kind})
     else:
-        client.send(RequestMethod.GET, url)
-    client.print(keys=["kind", "name", "tier", "description", "scale_summary"])
+        data, errors = client.send(RequestMethod.GET, url)
+    print_response(
+        data=data,
+        errors=errors,
+        keys=["kind", "name", "tier", "description", "scale_summary"],
+        output_fmt=get_output_format(args),
+    )

--- a/croud/projects/commands.py
+++ b/croud/projects/commands.py
@@ -19,6 +19,8 @@
 
 from argparse import Namespace
 
+from croud.config import get_output_format
+from croud.printer import print_response
 from croud.rest import Client
 from croud.session import RequestMethod
 from croud.util import org_id_config_fallback, require_confirmation
@@ -31,12 +33,18 @@ def project_create(args: Namespace) -> None:
     """
 
     client = Client.from_args(args)
-    client.send(
+    data, errors = client.send(
         RequestMethod.POST,
         "/api/v2/projects/",
         body={"name": args.name, "organization_id": args.org_id},
     )
-    client.print(keys=["id"])
+    print_response(
+        data=data,
+        errors=errors,
+        keys=["id"],
+        success_message="Project created.",
+        output_fmt=get_output_format(args),
+    )
 
 
 @require_confirmation(
@@ -48,8 +56,15 @@ def project_delete(args: Namespace) -> None:
     Deletes a project in the organization the user belongs to.
     """
     client = Client.from_args(args)
-    client.send(RequestMethod.DELETE, f"/api/v2/projects/{args.project_id}/")
-    client.print("Project deleted.")
+    data, errors = client.send(
+        RequestMethod.DELETE, f"/api/v2/projects/{args.project_id}/"
+    )
+    print_response(
+        data=data,
+        errors=errors,
+        success_message="Project deleted.",
+        output_fmt=get_output_format(args),
+    )
 
 
 def projects_list(args: Namespace) -> None:
@@ -58,5 +73,10 @@ def projects_list(args: Namespace) -> None:
     """
 
     client = Client.from_args(args)
-    client.send(RequestMethod.GET, "/api/v2/projects/")
-    client.print(keys=["id", "name", "region", "organization_id"])
+    data, errors = client.send(RequestMethod.GET, "/api/v2/projects/")
+    print_response(
+        data=data,
+        errors=errors,
+        keys=["id", "name", "region", "organization_id"],
+        output_fmt=get_output_format(args),
+    )

--- a/croud/projects/users/commands.py
+++ b/croud/projects/users/commands.py
@@ -19,6 +19,8 @@
 
 from argparse import Namespace
 
+from croud.config import get_output_format
+from croud.printer import print_response
 from croud.rest import Client
 from croud.session import RequestMethod
 
@@ -30,12 +32,23 @@ def project_users_add(args: Namespace) -> None:
 
     client = Client.from_args(args)
 
-    client.send(
+    data, errors = client.send(
         RequestMethod.POST,
         f"/api/v2/projects/{args.project_id}/users/",
         body={"user": args.user, "role_fqn": args.role},
     )
-    client.print(keys=["user_id", "project_id", "role_fqn"])
+    if data is not None and data.get("added", False):
+        success_message = "User added to project."
+    else:
+        success_message = "Role altered for user."
+
+    print_response(
+        data=data,
+        errors=errors,
+        keys=["user_id", "project_id", "role_fqn"],
+        success_message=success_message,
+        output_fmt=get_output_format(args),
+    )
 
 
 def project_users_remove(args: Namespace) -> None:
@@ -44,7 +57,12 @@ def project_users_remove(args: Namespace) -> None:
     """
 
     client = Client.from_args(args)
-    client.send(
+    data, errors = client.send(
         RequestMethod.DELETE, f"/api/v2/projects/{args.project_id}/users/{args.user}/"
     )
-    client.print(success_message="Successfully removed user from project.")
+    print_response(
+        data=data,
+        errors=errors,
+        success_message="User removed from project.",
+        output_fmt=get_output_format(args),
+    )

--- a/croud/rest.py
+++ b/croud/rest.py
@@ -20,13 +20,11 @@
 import asyncio
 from argparse import Namespace
 from functools import partial
-from typing import List, Optional, Union
 
 from aiohttp import ContentTypeError  # type: ignore
 from aiohttp.client_reqrep import ClientResponse
 
 from croud.config import Configuration
-from croud.printer import print_error, print_format, print_success
 from croud.session import HttpSession, RequestMethod
 
 
@@ -34,15 +32,11 @@ class Client:
     _env: str
     _token: str
     _region: str
-    _output_fmt: str
-    _data: Optional[Union[List[dict], dict]] = None
-    _error: Optional[dict] = None
 
     def __init__(self, env: str, region: str, output_fmt: str, loop=None):
         self._env = env or Configuration.get_env()
         self._token = Configuration.get_token(self._env)
         self._region = region or Configuration.get_setting("region")
-        self._output_fmt = output_fmt or Configuration.get_setting("output_fmt")
         self.loop = loop or asyncio.get_event_loop()
 
     @staticmethod
@@ -57,7 +51,7 @@ class Client:
         body: dict = None,
         params: dict = None
     ):
-        self.loop.run_until_complete(self.fetch(method, endpoint, body, params))
+        return self.loop.run_until_complete(self.fetch(method, endpoint, body, params))
 
     async def fetch(
         self,
@@ -66,24 +60,14 @@ class Client:
         body: dict = None,
         params: dict = None,
     ):
-        resp = await self._fetch(method, endpoint, body, params)
-
-        self._data, self._error = await self._decode_response(resp)
-
-    async def _fetch(
-        self,
-        method: RequestMethod,
-        endpoint: str,
-        body: dict = None,
-        params: dict = None,
-    ) -> ClientResponse:
         async with HttpSession(
             self._env,
             self._token,
             self._region,
             on_new_token=partial(Configuration.set_token, env=self._env),
         ) as session:
-            return await session.fetch(method, endpoint, body, params)
+            resp = await session.fetch(method, endpoint, body, params)
+            return await self._decode_response(resp)
 
     async def _decode_response(self, resp: ClientResponse):
         if resp.status == 204:
@@ -99,22 +83,4 @@ class Client:
         if resp.status >= 400:
             return None, body
         else:
-            data = body["data"] if "data" in body else body
-            return data, None
-
-    def print(self, success_message: str = None, keys: List[str] = None):
-        if self._error:
-            if "message" in self._error:
-                print_error(self._error["message"])
-                if "errors" in self._error:
-                    print_format(self._error["errors"], "json")
-            else:
-                print_format(self._error, "json")
-            return
-
-        if self._data is None:
-            message = success_message or "Success."
-            print_success(message)
-            return
-
-        print_format(self._data, self._output_fmt, keys)
+            return body, None

--- a/croud/users/roles/commands.py
+++ b/croud/users/roles/commands.py
@@ -20,8 +20,9 @@
 import textwrap
 from argparse import Namespace
 
+from croud.config import get_output_format
 from croud.gql import Query, print_query
-from croud.printer import print_warning
+from croud.printer import print_response, print_warning
 from croud.rest import Client
 from croud.session import RequestMethod
 from croud.util import clean_dict
@@ -74,8 +75,13 @@ def roles_list(args: Namespace) -> None:
     """
 
     client = Client.from_args(args)
-    client.send(RequestMethod.GET, "/api/v2/roles/")
-    client.print(keys=["id", "name"])
+    data, errors = client.send(RequestMethod.GET, "/api/v2/roles/")
+    print_response(
+        data=data,
+        errors=errors,
+        keys=["id", "name"],
+        output_fmt=get_output_format(args),
+    )
 
 
 def roles_remove(args: Namespace) -> None:

--- a/tests/unit_tests/test_authentication.py
+++ b/tests/unit_tests/test_authentication.py
@@ -112,7 +112,8 @@ class TestLogin:
 
         with mock.patch("croud.config.load_config", side_effect=cfg.read_config):
             with mock.patch("croud.config.write_config", side_effect=cfg.write_config):
-                login(Namespace(env="local"))
+                with mock.patch("croud.rest.Client.send", return_value=[None, None]):
+                    login(Namespace(env="local"))
 
         new_cfg = cfg.read_config()
         assert new_cfg["auth"]["current_context"] == "local"
@@ -159,48 +160,60 @@ class TestLogin:
     def test_get_org_id_no_org_is_superuser(self):
         cfg = MockConfig(Configuration.DEFAULT_CONFIG)
         cfg.conf["auth"]["contexts"]["dev"]["organization_id"]
-        client = mock.Mock(
-            _data={"is_superuser": True, "organization_id": None}, _error=None
-        )
         with mock.patch("croud.config.load_config", side_effect=cfg.read_config):
             with mock.patch("croud.config.write_config", side_effect=cfg.write_config):
-                with mock.patch("croud.login.Client", return_value=client):
+                with mock.patch(
+                    "croud.rest.Client.send",
+                    return_value=[
+                        {"is_superuser": True, "organization_id": None},
+                        None,
+                    ],
+                ):
                     org_id = get_org_id()
         assert org_id is None
 
     def test_get_org_id_org_is_superuser(self):
         cfg = MockConfig(Configuration.DEFAULT_CONFIG)
         cfg.conf["auth"]["contexts"]["dev"]["organization_id"]
-        client = mock.Mock(
-            _data={"is_superuser": True, "organization_id": "some-id"}, _error=None
-        )
         with mock.patch("croud.config.load_config", side_effect=cfg.read_config):
             with mock.patch("croud.config.write_config", side_effect=cfg.write_config):
-                with mock.patch("croud.login.Client", return_value=client):
+                with mock.patch(
+                    "croud.rest.Client.send",
+                    return_value=[
+                        {"is_superuser": True, "organization_id": "some_id"},
+                        None,
+                    ],
+                ):
                     org_id = get_org_id()
         assert org_id is None
 
     def test_get_org_id_no_org_is_not_superuser(self):
         cfg = MockConfig(Configuration.DEFAULT_CONFIG)
         cfg.conf["auth"]["contexts"]["dev"]["organization_id"]
-        client = mock.Mock(
-            _data={"is_superuser": False, "organization_id": None}, _error=None
-        )
         with mock.patch("croud.config.load_config", side_effect=cfg.read_config):
             with mock.patch("croud.config.write_config", side_effect=cfg.write_config):
-                with mock.patch("croud.login.Client", return_value=client):
+                with mock.patch(
+                    "croud.rest.Client.send",
+                    return_value=[
+                        {"is_superuser": False, "organization_id": None},
+                        None,
+                    ],
+                ):
                     org_id = get_org_id()
         assert org_id is None
 
     def test_get_org_id_org_is_not_superuser(self):
         cfg = MockConfig(Configuration.DEFAULT_CONFIG)
         cfg.conf["auth"]["contexts"]["dev"]["organization_id"]
-        client = mock.Mock(
-            _data={"is_superuser": False, "organization_id": "some-id"}, _error=None
-        )
         with mock.patch("croud.config.load_config", side_effect=cfg.read_config):
             with mock.patch("croud.config.write_config", side_effect=cfg.write_config):
-                with mock.patch("croud.login.Client", return_value=client):
+                with mock.patch(
+                    "croud.rest.Client.send",
+                    return_value=[
+                        {"is_superuser": False, "organization_id": "some-id"},
+                        None,
+                    ],
+                ):
                     org_id = get_org_id()
         assert org_id == "some-id"
 

--- a/tests/unit_tests/test_commands.py
+++ b/tests/unit_tests/test_commands.py
@@ -36,7 +36,7 @@ def gen_uuid() -> str:
 
 
 @mock.patch("croud.config.load_config", return_value=Configuration.DEFAULT_CONFIG)
-@mock.patch.object(Client, "send")
+@mock.patch.object(Client, "send", return_value=({}, None))
 class TestMe(CommandTestCase):
     def test_me(self, mock_send, mock_config):
         argv = ["croud", "me"]
@@ -137,14 +137,14 @@ class TestClusters(CommandTestCase):
     """
     ).strip()
 
-    @mock.patch.object(Client, "send")
+    @mock.patch.object(Client, "send", return_value=({}, None))
     def test_list_no_project_id(self, mock_send, mock_run, mock_load_config):
         argv = ["croud", "clusters", "list"]
         self.assertRest(
             mock_send, argv, RequestMethod.GET, "/api/v2/clusters/", params={}
         )
 
-    @mock.patch.object(Client, "send")
+    @mock.patch.object(Client, "send", return_value=({}, None))
     def test_list_with_project_id(self, mock_send, mock_run, mock_load_config):
         argv = ["croud", "clusters", "list", "--project-id", self.project_id]
         self.assertRest(
@@ -155,7 +155,7 @@ class TestClusters(CommandTestCase):
             params={"project_id": self.project_id},
         )
 
-    @mock.patch.object(Client, "send")
+    @mock.patch.object(Client, "send", return_value=({}, None))
     def test_deploy_cluster(self, mock_send, mock_run, mock_load_config):
         argv = [
             "croud",
@@ -196,7 +196,7 @@ class TestClusters(CommandTestCase):
             },
         )
 
-    @mock.patch.object(Client, "send")
+    @mock.patch.object(Client, "send", return_value=({}, None))
     def test_deploy_cluster_no_unit(self, mock_send, mock_run, mock_load_config):
         argv = [
             "croud",
@@ -234,7 +234,7 @@ class TestClusters(CommandTestCase):
             },
         )
 
-    @mock.patch.object(Client, "send")
+    @mock.patch.object(Client, "send", return_value=({}, None))
     def test_deploy_cluster_nightly(self, mock_send, mock_run, mock_load_config):
         argv = [
             "croud",
@@ -277,7 +277,7 @@ class TestClusters(CommandTestCase):
             },
         )
 
-    @mock.patch.object(Client, "send")
+    @mock.patch.object(Client, "send", return_value=({}, None))
     def test_scale_cluster(self, mock_send, mock_run, mock_load_config):
         unit = 1
         cluster_id = gen_uuid()
@@ -290,7 +290,7 @@ class TestClusters(CommandTestCase):
             body={"product_unit": unit},
         )
 
-    @mock.patch.object(Client, "send")
+    @mock.patch.object(Client, "send", return_value=({}, None))
     def test_upgrade_cluster(self, mock_send, mock_run, mock_load_config):
         version = "3.2.6"
         cluster_id = gen_uuid()
@@ -311,7 +311,7 @@ class TestClusters(CommandTestCase):
             body={"crate_version": version},
         )
 
-    @mock.patch.object(Client, "send")
+    @mock.patch.object(Client, "send", return_value=(None, {}))
     def test_clusters_delete(self, mock_send, mock_run, mock_load_config, capsys):
         cluster_id = gen_uuid()
         argv = ["croud", "clusters", "delete", "--cluster-id", cluster_id]
@@ -323,10 +323,11 @@ class TestClusters(CommandTestCase):
                 "Are you sure you want to delete the cluster? [yN] "
             )
 
-        out, _ = capsys.readouterr()
-        assert "Cluster deleted." in out
+        _, err_output = capsys.readouterr()
+        assert "Success" in err_output
+        assert "Cluster deleted." in err_output
 
-    @mock.patch.object(Client, "send")
+    @mock.patch.object(Client, "send", return_value=(None, {}))
     def test_clusters_delete_flag(self, mock_send, mock_run, mock_load_config, capsys):
         cluster_id = gen_uuid()
         argv = ["croud", "clusters", "delete", "--cluster-id", cluster_id, "-y"]
@@ -336,10 +337,11 @@ class TestClusters(CommandTestCase):
             )
             mock_input.assert_not_called()
 
-        out, _ = capsys.readouterr()
-        assert "Cluster deleted." in out
+        _, err_output = capsys.readouterr()
+        assert "Success" in err_output
+        assert "Cluster deleted." in err_output
 
-    @mock.patch.object(Client, "send")
+    @mock.patch.object(Client, "send", return_value=(None, {}))
     def test_clusters_delete_aborted(
         self, mock_send, mock_run, mock_load_config, capsys
     ):
@@ -352,13 +354,13 @@ class TestClusters(CommandTestCase):
                 "Are you sure you want to delete the cluster? [yN] "
             )
 
-        out, _ = capsys.readouterr()
-        assert "Cluster deletion cancelled." in out
+        _, err_output = capsys.readouterr()
+        assert "Cluster deletion cancelled." in err_output
 
 
 @mock.patch("croud.config.load_config", return_value=Configuration.DEFAULT_CONFIG)
-@mock.patch.object(Client, "send")
 class TestOrganizations(CommandTestCase):
+    @mock.patch.object(Client, "send", return_value=({}, None))
     def test_create(self, mock_send, mock_load_config):
         argv = [
             "croud",
@@ -377,10 +379,12 @@ class TestOrganizations(CommandTestCase):
             body={"name": "test-org", "plan_type": 1},
         )
 
+    @mock.patch.object(Client, "send", return_value=({}, None))
     def test_list(self, mock_send, mock_load_config):
         argv = ["croud", "organizations", "list"]
         self.assertRest(mock_send, argv, RequestMethod.GET, "/api/v2/organizations/")
 
+    @mock.patch.object(Client, "send", return_value=(None, {}))
     def test_delete(self, mock_send, mock_load_config, capsys):
         org_id = gen_uuid()
         argv = ["croud", "organizations", "delete", "--org-id", org_id]
@@ -395,9 +399,10 @@ class TestOrganizations(CommandTestCase):
                 "Are you sure you want to delete the organization? [yN] "
             )
 
-        out, _ = capsys.readouterr()
-        assert "Organization deleted." in out
+        _, err_output = capsys.readouterr()
+        assert "Organization deleted." in err_output
 
+    @mock.patch.object(Client, "send", return_value=(None, {}))
     def test_delete_flag(self, mock_send, mock_load_config, capsys):
         org_id = gen_uuid()
         argv = ["croud", "organizations", "delete", "--org-id", org_id, "-y"]
@@ -410,10 +415,11 @@ class TestOrganizations(CommandTestCase):
             )
             mock_input.assert_not_called()
 
-        out, _ = capsys.readouterr()
-        assert "Organization deleted." in out
+        _, err_output = capsys.readouterr()
+        assert "Organization deleted." in err_output
 
     @pytest.mark.parametrize("input", ["", "N", "No", "cancel"])
+    @mock.patch.object(Client, "send", return_value=(None, {}))
     def test_delete_aborted(self, mock_send, mock_load_config, capsys, input):
         org_id = gen_uuid()
         argv = ["croud", "organizations", "delete", "--org-id", org_id]
@@ -424,9 +430,10 @@ class TestOrganizations(CommandTestCase):
                 "Are you sure you want to delete the organization? [yN] "
             )
 
-        out, _ = capsys.readouterr()
-        assert "Organization deletion cancelled." in out
+        _, err_output = capsys.readouterr()
+        assert "Organization deletion cancelled." in err_output
 
+    @mock.patch.object(Client, "send", return_value=(None, {}))
     def test_delete_aborted_with_input(self, mock_send, mock_load_config, capsys):
         org_id = gen_uuid()
         argv = ["croud", "organizations", "delete", "--org-id", org_id]
@@ -437,9 +444,10 @@ class TestOrganizations(CommandTestCase):
                 "Are you sure you want to delete the organization? [yN] "
             )
 
-        out, _ = capsys.readouterr()
-        assert "Organization deletion cancelled." in out
+        _, err_output = capsys.readouterr()
+        assert "Organization deletion cancelled." in err_output
 
+    @mock.patch.object(Client, "send", return_value=({"added": True}, None))
     def test_add_user(self, mock_send, mock_load_config):
         org_id = gen_uuid()
         user = "test@crate.io"
@@ -465,6 +473,36 @@ class TestOrganizations(CommandTestCase):
             body={"user": user, "role_fqn": role_fqn},
         )
 
+    @mock.patch.object(Client, "send", return_value=({"added": False}, None))
+    def test_update_user(self, mock_send, mock_load_confg, capsys):
+        org_id = gen_uuid()
+        user = "test@crate.io"
+        role_fqn = "org_admin"
+
+        argv = [
+            "croud",
+            "organizations",
+            "users",
+            "add",
+            "--user",
+            user,
+            "--org-id",
+            org_id,
+            "--role",
+            role_fqn,
+        ]
+        self.assertRest(
+            mock_send,
+            argv,
+            RequestMethod.POST,
+            f"/api/v2/organizations/{org_id}/users/",
+            body={"user": user, "role_fqn": role_fqn},
+        )
+        _, err_output = capsys.readouterr()
+        assert "Success" in err_output
+        assert "Role altered for user." in err_output
+
+    @mock.patch.object(Client, "send", return_value=({}, None))
     def test_remove_user(self, mock_send, mock_load_config):
         org_id = gen_uuid()
         user = "test@crate.io"
@@ -488,8 +526,8 @@ class TestOrganizations(CommandTestCase):
 
 
 @mock.patch("croud.config.load_config", return_value=Configuration.DEFAULT_CONFIG)
-@mock.patch.object(Client, "send")
 class TestProjects(CommandTestCase):
+    @mock.patch.object(Client, "send", return_value=({}, None))
     def test_create(self, mock_send, mock_load_config):
         argv = [
             "croud",
@@ -508,6 +546,7 @@ class TestProjects(CommandTestCase):
             body={"name": "new-project", "organization_id": "organization-id"},
         )
 
+    @mock.patch.object(Client, "send", return_value=(None, {}))
     def test_delete(self, mock_send, mock_load_config, capsys):
         project_id = gen_uuid()
         argv = ["croud", "projects", "delete", "--project-id", project_id]
@@ -519,9 +558,11 @@ class TestProjects(CommandTestCase):
                 "Are you sure you want to delete the project? [yN] "
             )
 
-        out, _ = capsys.readouterr()
-        assert "Project deleted." in out
+        _, err_output = capsys.readouterr()
+        assert "Success" in err_output
+        assert "Project deleted." in err_output
 
+    @mock.patch.object(Client, "send", return_value=(None, {}))
     def test_delete_flag(self, mock_send, mock_load_config, capsys):
         project_id = gen_uuid()
         argv = ["croud", "projects", "delete", "--project-id", project_id, "-y"]
@@ -531,9 +572,11 @@ class TestProjects(CommandTestCase):
             )
             mock_input.assert_not_called()
 
-        out, _ = capsys.readouterr()
-        assert "Project deleted." in out
+        _, err_output = capsys.readouterr()
+        assert "Success" in err_output
+        assert "Project deleted." in err_output
 
+    @mock.patch.object(Client, "send", return_value=(None, {}))
     def test_delete_aborted(self, mock_send, mock_load_config, capsys):
         project_id = gen_uuid()
         argv = ["croud", "projects", "delete", "--project-id", project_id]
@@ -544,17 +587,18 @@ class TestProjects(CommandTestCase):
                 "Are you sure you want to delete the project? [yN] "
             )
 
-        out, _ = capsys.readouterr()
-        assert "Project deletion cancelled." in out
+        _, err_output = capsys.readouterr()
+        assert "Project deletion cancelled." in err_output
 
+    @mock.patch.object(Client, "send", return_value=({}, None))
     def test_list(self, mock_send, mock_load_config):
         argv = ["croud", "projects", "list"]
-        self.assertGql(mock_send, argv, RequestMethod.GET, "/api/v2/projects/")
+        self.assertRest(mock_send, argv, RequestMethod.GET, "/api/v2/projects/")
 
 
 @mock.patch("croud.config.load_config", return_value=Configuration.DEFAULT_CONFIG)
-@mock.patch.object(Client, "send")
 class TestProjectsUsers(CommandTestCase):
+    @mock.patch.object(Client, "send", return_value=({"added": True}, None))
     def test_add(self, mock_send, mock_load_config):
         project_id = gen_uuid()
 
@@ -582,6 +626,36 @@ class TestProjectsUsers(CommandTestCase):
             body={"user": user, "role_fqn": role_fqn},
         )
 
+    @mock.patch.object(Client, "send", return_value=({"added": False}, None))
+    def test_update(self, mock_send, mock_load_config, capsys):
+        project_id = gen_uuid()
+        user = "test@crate.io"
+        role_fqn = "project_admin"
+
+        argv = [
+            "croud",
+            "projects",
+            "users",
+            "add",
+            "--project-id",
+            project_id,
+            "--user",
+            user,
+            "--role",
+            role_fqn,
+        ]
+        self.assertRest(
+            mock_send,
+            argv,
+            RequestMethod.POST,
+            f"/api/v2/projects/{project_id}/users/",
+            body={"user": user, "role_fqn": role_fqn},
+        )
+        _, err_output = capsys.readouterr()
+        assert "Success" in err_output
+        assert "Role altered for user." in err_output
+
+    @mock.patch.object(Client, "send", return_value=({"added": True}, None))
     def test_remove(self, mock_send, mock_load_config):
         project_id = gen_uuid()
 
@@ -640,10 +714,10 @@ class TestUsersRoles(CommandTestCase):
             resource_id,
         ]
         self.assertGql(mock_run, argv, expected_body, expected_vars)
-        out, _ = capsys.readouterr()
+        _, err_output = capsys.readouterr()
         assert (
             "This command is deprecated. Please use `croud organizations users add` instead."  # noqa
-            in out
+            in err_output
         )
 
     def test_remove(self, mock_run, mock_load_config, capsys):
@@ -677,15 +751,15 @@ class TestUsersRoles(CommandTestCase):
             resource_id,
         ]
         self.assertGql(mock_run, argv, expected_body, expected_vars)
-        out, _ = capsys.readouterr()
+        _, err_output = capsys.readouterr()
         assert (
             "This command is deprecated. Please use `croud projects users remove` instead."  # noqa
-            in out
+            in err_output
         )
 
 
 @mock.patch("croud.config.load_config", return_value=Configuration.DEFAULT_CONFIG)
-@mock.patch.object(Client, "send")
+@mock.patch.object(Client, "send", return_value=({}, None))
 class TestUsersRolesREST(CommandTestCase):
     def test_list(self, mock_send, mock_load_config):
         argv = ["croud", "users", "roles", "list"]
@@ -739,13 +813,13 @@ class TestUsers(CommandTestCase):
 
 
 @mock.patch("croud.config.load_config", return_value=Configuration.DEFAULT_CONFIG)
-@mock.patch.object(Client, "send")
 class TestConsumers(CommandTestCase):
     # fmt: off
     eventhub_dsn = "Endpoint=sb://myhub.servicebus.windows.net/;SharedAccessKeyName=...;SharedAccessKey=...;EntityPath=..."  # noqa
     storage_dsn = "DefaultEndpointsProtocol=https;AccountName=...;AccountKey=...;EndpointSuffix=core.windows.net"  # noqa
     # fmt: on
 
+    @mock.patch.object(Client, "send", return_value=["data", "errors"])
     def test_deploy_consumer(self, mock_send, mock_load_config):
         project_id = gen_uuid()
         cluster_id = gen_uuid()
@@ -803,12 +877,14 @@ class TestConsumers(CommandTestCase):
             },
         )
 
+    @mock.patch.object(Client, "send", return_value=({}, None))
     def test_consumers_list(self, mock_send, mock_load_config):
         argv = ["croud", "consumers", "list"]
         self.assertRest(
             mock_send, argv, RequestMethod.GET, "/api/v2/consumers/", params={}
         )
 
+    @mock.patch.object(Client, "send", return_value=({}, None))
     def test_consumers_list_with_params(self, mock_send, mock_load_config):
         project_id = gen_uuid()
         cluster_id = gen_uuid()
@@ -835,6 +911,7 @@ class TestConsumers(CommandTestCase):
             },
         )
 
+    @mock.patch.object(Client, "send", return_value=({}, None))
     def test_consumers_edit(self, mock_send, mock_load_config):
         consumer_id = gen_uuid()
         cluster_id = gen_uuid()
@@ -879,6 +956,7 @@ class TestConsumers(CommandTestCase):
             },
         )
 
+    @mock.patch.object(Client, "send", return_value=(None, {}))
     def test_consumers_delete(self, mock_send, mock_load_config, capsys):
         consumer_id = gen_uuid()
         argv = ["croud", "consumers", "delete", "--consumer-id", consumer_id]
@@ -893,9 +971,11 @@ class TestConsumers(CommandTestCase):
                 "Are you sure you want to delete the consumer? [yN] "
             )
 
-        out, _ = capsys.readouterr()
-        assert "Consumer deleted." in out
+        _, err_output = capsys.readouterr()
+        assert "Success" in err_output
+        assert "Consumer deleted." in err_output
 
+    @mock.patch.object(Client, "send", return_value=(None, {}))
     def test_consumers_delete_flag(self, mock_send, mock_load_config, capsys):
         consumer_id = gen_uuid()
         argv = ["croud", "consumers", "delete", "--consumer-id", consumer_id, "-y"]
@@ -908,9 +988,11 @@ class TestConsumers(CommandTestCase):
             )
             mock_input.assert_not_called()
 
-        out, _ = capsys.readouterr()
-        assert "Consumer deleted." in out
+        _, err_output = capsys.readouterr()
+        assert "Success" in err_output
+        assert "Consumer deleted." in err_output
 
+    @mock.patch.object(Client, "send", return_value=(None, {}))
     def test_consumers_delete_aborted(self, mock_send, mock_load_config, capsys):
         consumer_id = gen_uuid()
         argv = ["croud", "consumers", "delete", "--consumer-id", consumer_id]
@@ -921,12 +1003,12 @@ class TestConsumers(CommandTestCase):
                 "Are you sure you want to delete the consumer? [yN] "
             )
 
-        out, _ = capsys.readouterr()
-        assert "Consumer deletion cancelled." in out
+        _, err_output = capsys.readouterr()
+        assert "Consumer deletion cancelled." in err_output
 
 
 @mock.patch("croud.config.load_config", return_value=Configuration.DEFAULT_CONFIG)
-@mock.patch.object(Client, "send")
+@mock.patch.object(Client, "send", return_value=({}, None))
 class TestGrafana(CommandTestCase):
     project_id = gen_uuid()
 
@@ -968,12 +1050,12 @@ class TestGrafana(CommandTestCase):
 @mock.patch("croud.config.load_config", return_value=Configuration.DEFAULT_CONFIG)
 @mock.patch.object(Query, "run", return_value={"data": []})
 class TestProducts(CommandTestCase):
-    @mock.patch.object(Client, "send")
+    @mock.patch.object(Client, "send", return_value=({}, None))
     def test_list(self, mock_send, mock_run, mock_load_config):
         argv = ["croud", "products", "list"]
         self.assertRest(mock_send, argv, RequestMethod.GET, "/api/v2/products/")
 
-    @mock.patch.object(Client, "send")
+    @mock.patch.object(Client, "send", return_value=({}, None))
     def test_list_kind(self, mock_send, mock_run, mock_load_config):
         argv = ["croud", "products", "list", "--kind", "cluster"]
         self.assertRest(

--- a/tests/unit_tests/test_printer.py
+++ b/tests/unit_tests/test_printer.py
@@ -19,7 +19,12 @@
 
 import pytest
 
-from croud.printer import JsonFormatPrinter, TableFormatPrinter, YamlFormatPrinter
+from croud.printer import (
+    JsonFormatPrinter,
+    TableFormatPrinter,
+    YamlFormatPrinter,
+    print_response,
+)
 
 
 @pytest.mark.parametrize(
@@ -161,3 +166,47 @@ def test_yaml_format(rows, expected):
 def test_tabular_format(rows, keys, expected):
     out = TableFormatPrinter(keys=keys).format_rows(rows)
     assert out == expected
+
+
+def test_print_response(capsys):
+    data = {"email": "test@crate.io", "username": "Google_1234"}
+    errors = None
+    output_fmt = "json"
+    print_response(data, errors, output_fmt)
+    output, _ = capsys.readouterr()
+    assert "test@crate.io" in output
+    assert "Google_1234" in output
+
+
+def test_print_response_success_message(capsys):
+    data = None
+    errors = {}
+    output_fmt = "json"
+    success_message = "Deleted cluster."
+    print_response(data, errors, output_fmt, success_message)
+    _, err_output = capsys.readouterr()
+    assert "Success" in err_output
+    assert "Deleted cluster." in err_output
+
+
+def test_print_response_error(capsys):
+    data = None
+    errors = {"message": "Resource not found.", "success": False}
+    output_fmt = "table"
+    print_response(data, errors, output_fmt)
+    _, err_output = capsys.readouterr()
+    assert "Error" in err_output
+    assert "Resource not found." in err_output
+
+
+def test_print_response_data_success(capsys):
+    data = {"a": 1, "b": 2}
+    errors = {}
+    output_fmt = "json"
+    success_message = "Posted numbers."
+    print_response(data, errors, output_fmt, success_message)
+    output, err_output = capsys.readouterr()
+    assert '"a": 1' in output
+    assert '"b": 2' in output
+    assert "Success" in err_output
+    assert "Posted numbers." in err_output

--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -161,8 +161,11 @@ def test_require_confirmation(
         else:
             mock_input.assert_called()
 
-    out, _ = capsys.readouterr()
-    assert output in out
+    out, err_output = capsys.readouterr()
+    if err_output != "":
+        assert out in err_output
+    else:
+        assert output in out
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
- Updated the feedback messages of several commands.

 - Added the `print_response` function to be able to print the feedback messages of the
  commands.

 - Reworked REST client:

   - The `_fetch` function is now part of `fetch` and returns the response data and errors.
   - Removed the `client.print` function.
   - Removed the private fields `_data`, `_error` and `_output_fmt`.


## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
