### PR TITLE
Store a user's organization ID upon login and use as fallback for --org-id

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changes for croud
 Unreleased
 ==========
 
+- The ``-org-id`` parameter is now optional for non-superusers. Upon login, a
+  user's organization will be retrieved and stored in the configuration file.
+  Whenever the ``--org-id`` parameter is needed, a fallback to the default
+  organization will be made.
+
 - Added support for YAML output. It can be specified with the ``-o yaml``
   argument.
 

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -217,7 +217,7 @@ command_tree = {
                 "extra_args": [
                     project_name_arg,
                     lambda req_opt_group, opt_opt_group: org_id_arg(
-                        req_opt_group, opt_opt_group, True
+                        req_opt_group, opt_opt_group, False
                     ),
                 ],
                 "resolver": project_create,
@@ -369,7 +369,7 @@ command_tree = {
                 "extra_args": [
                     yes_arg,
                     lambda req_opt_group, opt_opt_group: org_id_arg(
-                        req_opt_group, opt_opt_group, True
+                        req_opt_group, opt_opt_group, False
                     ),
                 ],
                 "resolver": organizations_delete,
@@ -385,7 +385,7 @@ command_tree = {
                                 req_opt_group, opt_opt_group, True
                             ),
                             lambda req_opt_group, opt_opt_group: org_id_arg(
-                                req_opt_group, opt_opt_group, True
+                                req_opt_group, opt_opt_group, False
                             ),
                         ],
                         "resolver": org_users_add,
@@ -395,7 +395,7 @@ command_tree = {
                         "extra_args": [
                             user_id_or_email_arg,
                             lambda req_opt_group, opt_opt_group: org_id_arg(
-                                req_opt_group, opt_opt_group, True
+                                req_opt_group, opt_opt_group, False
                             ),
                         ],
                         "resolver": org_users_remove,

--- a/croud/logout.py
+++ b/croud/logout.py
@@ -34,6 +34,7 @@ def logout(args: Namespace) -> None:
 
     loop.run_until_complete(make_request(env, token))
     Configuration.set_token("", env)
+    Configuration.set_organization_id("", env)
 
     print_info("You have been logged out.")
 

--- a/croud/organizations/commands.py
+++ b/croud/organizations/commands.py
@@ -19,9 +19,10 @@
 
 from argparse import Namespace
 
+from croud.config import Configuration
 from croud.rest import Client
 from croud.session import RequestMethod
-from croud.util import require_confirmation
+from croud.util import org_id_config_fallback, require_confirmation
 
 
 def organizations_create(args: Namespace) -> None:
@@ -48,6 +49,7 @@ def organizations_list(args: Namespace) -> None:
     client.print(keys=["id", "name", "plan_type"])
 
 
+@org_id_config_fallback
 @require_confirmation(
     "Are you sure you want to delete the organization?",
     cancel_msg="Organization deletion cancelled.",
@@ -60,3 +62,8 @@ def organizations_delete(args: Namespace) -> None:
     client = Client.from_args(args)
     client.send(RequestMethod.DELETE, f"/api/v2/organizations/{args.org_id}/")
     client.print("Organization deleted.")
+
+    env = args.env or Configuration.get_env()
+    config_org_id = Configuration.get_organization_id(env)
+    if args.org_id == config_org_id:
+        Configuration.set_organization_id("", Configuration.get_env())

--- a/croud/organizations/users/commands.py
+++ b/croud/organizations/users/commands.py
@@ -24,8 +24,10 @@ from argparse import Namespace
 
 from croud.rest import Client
 from croud.session import RequestMethod
+from croud.util import org_id_config_fallback
 
 
+@org_id_config_fallback
 def org_users_add(args: Namespace):
     client = Client.from_args(args)
 
@@ -37,6 +39,7 @@ def org_users_add(args: Namespace):
     client.print(keys=["user_id", "role_fqn", "organization_id"])
 
 
+@org_id_config_fallback
 def org_users_remove(args: Namespace):
     client = Client.from_args(args)
 

--- a/croud/projects/commands.py
+++ b/croud/projects/commands.py
@@ -21,9 +21,10 @@ from argparse import Namespace
 
 from croud.rest import Client
 from croud.session import RequestMethod
-from croud.util import require_confirmation
+from croud.util import org_id_config_fallback, require_confirmation
 
 
+@org_id_config_fallback
 def project_create(args: Namespace) -> None:
     """
     Creates a project in the organization the user belongs to.

--- a/croud/users/commands.py
+++ b/croud/users/commands.py
@@ -20,6 +20,7 @@
 import textwrap
 from argparse import Namespace
 
+from croud.config import Configuration
 from croud.gql import Query, print_query
 from croud.util import clean_dict
 
@@ -28,6 +29,13 @@ def users_list(args: Namespace) -> None:
     """
     List all users within organizations that the logged in user is part of
     """
+    org_id = (
+        args.org_id
+        or Configuration.get_organization_id(args.env or Configuration.get_env())
+        or None
+    )
+    if args.no_org:
+        org_id = None
 
     body = textwrap.dedent(
         """
@@ -43,9 +51,7 @@ def users_list(args: Namespace) -> None:
     """
     ).strip()
 
-    vars = clean_dict(
-        {"queryArgs": {"noOrg": args.no_org, "organizationId": args.org_id}}
-    )
+    vars = clean_dict({"queryArgs": {"noOrg": args.no_org, "organizationId": org_id}})
 
     query = Query(body, args)
     query.execute(vars)

--- a/croud/util.py
+++ b/croud/util.py
@@ -25,7 +25,8 @@ import webbrowser
 from argparse import Namespace
 from typing import Dict, Tuple
 
-from croud.printer import print_info
+from croud.config import Configuration
+from croud.printer import print_error, print_info
 
 
 # This function was copied from the <https://github.com/Azure/azure-cli>
@@ -120,3 +121,17 @@ def require_confirmation(
         return _wrapper
 
     return _inner
+
+
+def org_id_config_fallback(cmd):  # decorator
+    @functools.wraps(cmd)
+    def _wrapper(cmd_args: Namespace):  # decorator logic
+        env = cmd_args.env or Configuration.get_env()
+        cmd_args.org_id = cmd_args.org_id or Configuration.get_organization_id(env)
+        if not cmd_args.org_id:
+            print_error("An organization ID is required. Please pass --org-id.")
+            exit(1)
+
+        cmd(cmd_args)
+
+    return _wrapper


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement


## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
