### PR TITLE
Store organization ID for superusers but require --org-id when using --sudo

### DIFF
--- a/croud/login.py
+++ b/croud/login.py
@@ -38,8 +38,7 @@ def get_org_id() -> Optional[str]:
     )
     data, error = client.send(RequestMethod.GET, "/api/v2/users/me/")
     if data and not error:
-        if not data.get("is_superuser") and "organization_id" in data:
-            return data.get("organization_id")
+        return data.get("organization_id")
     return None
 
 

--- a/croud/util.py
+++ b/croud/util.py
@@ -126,6 +126,10 @@ def require_confirmation(
 def org_id_config_fallback(cmd):  # decorator
     @functools.wraps(cmd)
     def _wrapper(cmd_args: Namespace):  # decorator logic
+        if cmd_args.sudo and not cmd_args.org_id:
+            print_error("An organization ID is required. Please pass --org-id.")
+            exit(1)
+
         env = cmd_args.env or Configuration.get_env()
         cmd_args.org_id = cmd_args.org_id or Configuration.get_organization_id(env)
         if not cmd_args.org_id:

--- a/tests/unit_tests/test_authentication.py
+++ b/tests/unit_tests/test_authentication.py
@@ -157,65 +157,29 @@ class TestLogin:
         url = _login_url("invalid")
         assert "https://bregenz.a1.cratedb.cloud/oauth2/login?cli=true" == url
 
-    def test_get_org_id_no_org_is_superuser(self):
+    def test_get_org_id_no_org(self):
         cfg = MockConfig(Configuration.DEFAULT_CONFIG)
         cfg.conf["auth"]["contexts"]["dev"]["organization_id"]
         with mock.patch("croud.config.load_config", side_effect=cfg.read_config):
             with mock.patch("croud.config.write_config", side_effect=cfg.write_config):
                 with mock.patch(
                     "croud.rest.Client.send",
-                    return_value=[
-                        {"is_superuser": True, "organization_id": None},
-                        None,
-                    ],
+                    return_value=[{"organization_id": None}, None],
                 ):
                     org_id = get_org_id()
         assert org_id is None
 
-    def test_get_org_id_org_is_superuser(self):
+    def test_get_org_id_org(self):
         cfg = MockConfig(Configuration.DEFAULT_CONFIG)
         cfg.conf["auth"]["contexts"]["dev"]["organization_id"]
         with mock.patch("croud.config.load_config", side_effect=cfg.read_config):
             with mock.patch("croud.config.write_config", side_effect=cfg.write_config):
                 with mock.patch(
                     "croud.rest.Client.send",
-                    return_value=[
-                        {"is_superuser": True, "organization_id": "some_id"},
-                        None,
-                    ],
+                    return_value=[{"organization_id": "some_id"}, None],
                 ):
                     org_id = get_org_id()
-        assert org_id is None
-
-    def test_get_org_id_no_org_is_not_superuser(self):
-        cfg = MockConfig(Configuration.DEFAULT_CONFIG)
-        cfg.conf["auth"]["contexts"]["dev"]["organization_id"]
-        with mock.patch("croud.config.load_config", side_effect=cfg.read_config):
-            with mock.patch("croud.config.write_config", side_effect=cfg.write_config):
-                with mock.patch(
-                    "croud.rest.Client.send",
-                    return_value=[
-                        {"is_superuser": False, "organization_id": None},
-                        None,
-                    ],
-                ):
-                    org_id = get_org_id()
-        assert org_id is None
-
-    def test_get_org_id_org_is_not_superuser(self):
-        cfg = MockConfig(Configuration.DEFAULT_CONFIG)
-        cfg.conf["auth"]["contexts"]["dev"]["organization_id"]
-        with mock.patch("croud.config.load_config", side_effect=cfg.read_config):
-            with mock.patch("croud.config.write_config", side_effect=cfg.write_config):
-                with mock.patch(
-                    "croud.rest.Client.send",
-                    return_value=[
-                        {"is_superuser": False, "organization_id": "some-id"},
-                        None,
-                    ],
-                ):
-                    org_id = get_org_id()
-        assert org_id == "some-id"
+        assert org_id == "some_id"
 
 
 class TestLogout:


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement


## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
