### PR TITLE
Prepare release 0.17.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,8 @@ Changes for croud
 Unreleased
 ==========
 
-- Fixed a bug with the ``croud config set/get`` command which would the command
-  to fail.
+0.17.0 - 2019/07/31
+===================
 
 - Updated ``croud users list`` to include all user roles.
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@
 from pkg_resources.extern.packaging.version import Version
 from setuptools import find_packages, setup
 
-__version__ = Version("0.17.dev0")
+__version__ = Version("0.17.0")
 
 try:
     with open("README.rst", "r", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
- Updated ``croud users list`` to include all user roles.

- Depreated ``--no-org`` argument to ``croud users list`` in favor of ``--no-roles``.

- Added the ``croud projects users list`` command to list all user within a project.

- Added the ``croud organizations users list`` command to list all user within an
  organization.

- Added the optional ``--sudo`` argument to be able to specify when a command should
  be run as ``superuser``.

- The ``-org-id`` parameter is now optional for non-superusers. Upon login, a
  user's organization will be retrieved and stored in the configuration file.
  Whenever the ``--org-id`` parameter is needed, a fallback to the default
  organization will be made.

- Added support for YAML output. It can be specified with the ``-o yaml``
  argument.

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
