### PR TITLE
Bump PyYAML to modern version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         "aiohttp==3.4.4",
         "colorama==0.4.1",
         "appdirs==1.4.3",
-        "pyyaml==3.13",
+        "pyyaml==5.1.2",
         "certifi",
         "tabulate==0.8.2",
         "schema==0.6.8",


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

With Python 3.8 not too far away, it's time to drop version of PyYAML
that won't support 3.8 and upgrade to a recent version:

  DeprecationWarning: Using or importing the ABCs from 'collections'
  instead of from 'collections.abc' is deprecated, and in 3.8 it will
  stop working


## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
