### PR TITLE
Handle client networking errors correctly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for croud
 Unreleased
 ==========
 
+- Handle client networking errors correctly by printing a sensible error message
+  instead of a traceback.
+
 0.18.1 - 2019/08/09
 ===================
 

--- a/croud/rest.py
+++ b/croud/rest.py
@@ -24,6 +24,7 @@ from functools import partial
 from typing import Optional
 
 from aiohttp import ClientResponse, ContentTypeError, TCPConnector  # type: ignore
+from aiohttp.client_exceptions import ClientConnectorError
 
 from croud.config import Configuration
 from croud.session import HttpSession, RequestMethod
@@ -60,7 +61,7 @@ class Client:
         endpoint: str,
         *,
         body: dict = None,
-        params: dict = None
+        params: dict = None,
     ):
         return self.loop.run_until_complete(self.fetch(method, endpoint, body, params))
 
@@ -79,8 +80,17 @@ class Client:
             headers={"X-Auth-Sudo": str(uuid.uuid4())} if self._sudo is True else {},
             conn=self.conn,
         ) as session:
-            resp = await session.fetch(method, endpoint, body, params)
-            return await self._decode_response(resp)
+            try:
+                resp = await session.fetch(method, endpoint, body, params)
+            except ClientConnectorError as e:
+                message = (
+                    f"Failed to perform command on {e.host}. "
+                    f"Original error was: '{e}' "
+                    f"Does the environment exist in the region you specified?"
+                )
+                return None, {"message": message, "success": False}
+            else:
+                return await self._decode_response(resp)
 
     async def _decode_response(self, resp: ClientResponse):
         if resp.status == 204:

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -121,3 +121,15 @@ def test_client_initialization(mock_cloud_url, mock_token, event_loop):
     assert client._region == "bregenz.a1"
     assert client._sudo is True
     assert isinstance(client.loop, asyncio.AbstractEventLoop)
+
+
+@mock.patch("croud.session.cloud_url", return_value="https://invalid.cratedb.local")
+def test_error_message_on_connection_error(mock_cloud_url, client):
+    expected_message = (
+        "Failed to perform command on invalid.cratedb.local. "
+        "Original error was: 'Cannot connect to host invalid.cratedb.local:443 ssl:None [Name or service not known]' "  # noqa
+        "Does the environment exist in the region you specified?"
+    )
+    resp_data, errors = client.send(RequestMethod.GET, "/me")
+    assert resp_data is None
+    assert errors == {"message": expected_message, "success": False}


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Print only a sensible error message instead the full traceback.


## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
