### PR TITLE
Fix help text in new auditlog command

### DIFF
--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -502,7 +502,7 @@ command_tree = {
                 "resolver": organizations_delete,
             },
             "auditlogs": {
-                "help": "Show auditlogs for an organization",
+                "help": "Show audit logs for an organization.",
                 "commands": {
                     "list": {
                         "help": "List all audit events in the current organization.",
@@ -513,7 +513,8 @@ command_tree = {
                             ),
                             Argument(
                                 "--from", type=str, required=False, dest="from_",
-                                help="Only show events newer than this.",
+                                help="Only show events from this point in time.",
+                                metavar="FROM",
                             ),
                             Argument(
                                 "--to", type=str, required=False,


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Refs 9a08bb41b41bc26a740517814139b62d3ed81ace

```
$ croud organizations -h               
Usage: croud organizations [-h] {create,list,edit,delete,auditlogs,users} ...

Available Commands:
  create      Create a new organization.
  list        List all organizations the current user has access to.
  edit        Edit the specified organization.
  delete      Delete the specified organization.
  auditlogs   Show audit logs for an organization.
  users       Manage users in an organization.

Optional Arguments:
  -h, --help  Show this help message and exit.
```

```
$ croud organizations auditlogs list -h
Usage: croud organizations auditlogs list [-h] [--action ACTION] [--from FROM]
                                          [--to TO] [--org-id ORG_ID]
                                          [--region {westeurope.azure,eastus2.azure,bregenz.a1,eastus.azure}]
                                          [--env {prod,dev,local}]
                                          [--output-fmt {yaml,json,table}]
                                          [--sudo]

Optional Arguments:
  -h, --help            Show this help message and exit.
  --action ACTION       The audit event action.
  --from FROM           Only show events from this point in time.
  --to TO               Only show events older than this.
  --org-id ORG_ID       The organization ID to use.
  --region {westeurope.azure,eastus2.azure,bregenz.a1,eastus.azure}, -r {westeurope.azure,eastus2.azure,bregenz.a1,eastus.azure}
                        Temporarily use the specified region that command will
                        be run in.
  --env {prod,dev,local}, -e {prod,dev,local}
                        Switches auth context.
  --output-fmt {yaml,json,table}, -o {yaml,json,table}
                        Change the formatting of the output
  --sudo                Run the given command as superuser.
```

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
