### PR TITLE
Add Github action to build & upload to PyPi

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,26 @@
+---
+name: Release
+on: push
+jobs:
+  pypi:
+    name: Build and publish to PyPI
+    if: startsWith(github.event.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install setuptools and wheel
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+      - name: Build sdist and wheel
+        run: |
+          python setup.py sdist bdist_wheel
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.1.0
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -125,15 +125,16 @@ Release
     ./dev/tools/create_tag.sh
 
 
-Upload to `PyPI`_
------------------
+Upload to PyPI
+--------------
 
-See the instructions for `Generating distribution archives`_ for more details.
+Pushing a tag to Github will trigger a Github workflow that builds and uploads
+the ``croud`` package to `PyPI`_ automatically.
 
 .. note::
 
-    It is recommended to upload the package to `Test PyPI`_ first which is intended
-    for experimentation and testing.
+    It is recommended to build a package locally and upload it to `Test PyPI`_
+    first which is intended for experimentation and testing.
 
 
 Documentation
@@ -197,7 +198,6 @@ release version), please contact the `@crate/docs`_ team.
 .. _configured: https://github.com/crate/croud/blob/master/.travis.yml
 .. _flake8: https://gitlab.com/pycqa/flake8
 .. _fswatch: https://github.com/emcrisostomo/fswatch
-.. _Generating distribution archives: https://packaging.python.org/tutorials/packaging-projects/#generating-distribution-archives
 .. _isort: https://github.com/timothycrosley/isort
 .. _mypy: https://github.com/python/mypy
 .. _pre-commit: https://pre-commit.com


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

The Github action job is triggered whenever a tag is pushed. It builds
the source distribution package and the wheel and uploads them to PyPi.