### PR TITLE
Prepare release 0.23.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for croud
 Unreleased
 ==========
 
+0.23.0 - 2020/04/10
+===================
+
 - Added ``croud regions list`` command to list available regions to the user.
 
 - Introduced configuration profiles which replace the existing configuration

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@
 from pkg_resources.extern.packaging.version import Version
 from setuptools import find_packages, setup
 
-__version__ = Version("0.23.dev0")
+__version__ = Version("0.23.0")
 
 try:
     with open("README.rst", "r", encoding="utf-8") as f:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@
 from pkg_resources.extern.packaging.version import Version
 from setuptools import find_packages, setup
 
-__version__ = Version("0.23.0")
+__version__ = Version("0.24.dev0")
 
 try:
     with open("README.rst", "r", encoding="utf-8") as f:


### PR DESCRIPTION
**Attention, this release contains a breaking change to the configuration file.**

Since the new profiles are incompatible with the existing configuration, you are asked to delete the existing configuration file when you run croud for the first time after the update.

Please run `croud config --help` or `croud config profiles --help` thereafter or conduct the documentation for further information how to use the profiles.