### PR TITLE
Warning that users commands are for superusers only

### DIFF
--- a/croud/parser.py
+++ b/croud/parser.py
@@ -140,7 +140,7 @@ def add_default_args(parser, omit: Set[str]):
             "-o",
             required=False,
             choices=OUTPUT_FORMATS,
-            help="Change the formatting of the output",
+            help="Change the formatting of the output.",
         )
     if "sudo" not in omit:
         parser._group_optional.add_argument(

--- a/docs/commands/users.rst
+++ b/docs/commands/users.rst
@@ -15,6 +15,13 @@ The ``users`` command allows you to view user resources.
 ``users list``
 ==============
 
+.. warning::
+
+    The commands listed in this section (``users list``) are for internal use
+    by CrateDB and CrateDB Cloud staff only. They are listed here only to
+    clarify their function, since they appear in the full commands list
+    available under ``--help``.
+
 .. argparse::
    :module: croud.__main__
    :func: get_parser

--- a/docs/user-roles.rst
+++ b/docs/user-roles.rst
@@ -4,11 +4,13 @@
 User Roles
 ==========
 
-This is an overview over the user roles users can have in the `CrateDB Cloud`_.
+This is an overview over the user roles users can have in `CrateDB Cloud`_ for
+the purposes of the Croud CLI.
 
 .. tip::
 
-   The ``users roles list`` command provides a list of fully qualified role names.
+   The ``users roles list`` command provides a list of fully qualified role
+   names.
 
 .. rubric:: Table of Contents
 
@@ -64,6 +66,14 @@ Project member
 
 * Project member has read-only access to the project (settings, products,
   users).
+
+
+.. _roles-superuser:
+
+Superuser
+=========
+
+The superuser role is reserved internally for CrateDB and CrateDB Cloud staff.
 
 
 .. _CrateDB Cloud: https://crate.io/products/cratedb-cloud/


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Adds warning to Croud docs section on user commands that these are for Cloud staff (superusers) only and are only listed because they are currently present in the argparse configuration for --help. Corresponds to [this old story/impediment](https://trello.com/c/2uUClYL5/251-fix-customer-facing-docs-for-croud-users-command). 

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
