### PR TITLE
Deprecated the croud consumers commands

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for croud
 Unreleased
 ==========
 
+- Deprecated the ``croud consumers`` commands ``deploy``, ``list``,
+  ``edit`` and ``delete``, as they will be removed in the future.
+
 0.23.1 - 2020/05/06
 ===================
 

--- a/croud/consumers/commands.py
+++ b/croud/consumers/commands.py
@@ -21,11 +21,16 @@ from argparse import Namespace
 
 from croud.api import Client
 from croud.config import get_output_format
-from croud.printer import print_response
+from croud.printer import print_response, print_warning
 from croud.util import require_confirmation
 
 
 def consumers_deploy(args: Namespace) -> None:
+    """
+    The consumer deploy command is deprecated and will be removed in the future.
+    There is no explicit deprecation warning being raised, as the API endpoint is
+    providing the deprecation message.
+    """
     body = {
         "cluster_id": args.cluster_id,
         "config": {
@@ -66,6 +71,9 @@ def consumers_deploy(args: Namespace) -> None:
 
 
 def consumers_list(args: Namespace) -> None:
+    print_warning(
+        "The consumers list command is deprecated and will be removed in the future."
+    )
     params = {}
     if args.cluster_id:
         params["cluster_id"] = args.cluster_id
@@ -95,6 +103,9 @@ def consumers_list(args: Namespace) -> None:
 
 
 def consumers_edit(args: Namespace) -> None:
+    print_warning(
+        "The consumers edit command is deprecated and will be removed in the future."
+    )
     body = {
         "cluster_id": args.cluster_id,
         "table_name": args.consumer_table,
@@ -124,6 +135,9 @@ def consumers_edit(args: Namespace) -> None:
     cancel_msg="Consumer deletion cancelled.",
 )
 def consumers_delete(args: Namespace) -> None:
+    print_warning(
+        "The consumers delete command is deprecated and will be removed in the future."
+    )
     client = Client.from_args(args)
     data, errors = client.delete(f"/api/v2/consumers/{args.consumer_id}/")
     print_response(

--- a/docs/commands/consumers.rst
+++ b/docs/commands/consumers.rst
@@ -2,6 +2,11 @@
 ``consumers``
 =============
 
+.. warning::
+
+    These commands are deprecated and will be removed in the future.
+
+
 The ``consumers`` command lets you manage consumer products.
 
 .. tip::
@@ -13,6 +18,10 @@ The ``consumers`` command lets you manage consumer products.
 
 ``consumers deploy``
 ====================
+
+.. warning::
+
+    This command is deprecated and will be removed in the future.
 
 .. argparse::
    :module: croud.__main__
@@ -49,6 +58,10 @@ Example
 ``consumers list``
 ==================
 
+.. warning::
+
+    This command is deprecated and will be removed in the future.
+
 .. argparse::
    :module: croud.__main__
    :func: get_parser
@@ -70,6 +83,10 @@ Example
 
 ``consumers edit``
 ==================
+
+.. warning::
+
+    This command is deprecated and will be removed in the future.
 
 .. argparse::
    :module: croud.__main__
@@ -94,6 +111,10 @@ Example
 
 ``consumers delete``
 ====================
+
+.. warning::
+
+    This command is deprecated and will be removed in the future.
 
 .. argparse::
    :module: croud.__main__

--- a/tests/commands/test_consumers.py
+++ b/tests/commands/test_consumers.py
@@ -89,13 +89,18 @@ def test_consumers_deploy(mock_request):
 
 
 @mock.patch.object(Client, "request", return_value=({}, None))
-def test_consumers_list(mock_request):
+def test_consumers_list(mock_request, capsys):
     call_command("croud", "consumers", "list")
     assert_rest(mock_request, RequestMethod.GET, "/api/v2/consumers/", params={})
+    _, err = capsys.readouterr()
+    assert (
+        "The consumers list command is deprecated and will be removed in the future."
+        in err
+    )
 
 
 @mock.patch.object(Client, "request", return_value=({}, None))
-def test_consumers_list_with_params(mock_request):
+def test_consumers_list_with_params(mock_request, capsys):
     project_id = gen_uuid()
     cluster_id = gen_uuid()
     call_command(
@@ -119,10 +124,15 @@ def test_consumers_list_with_params(mock_request):
             "cluster_id": cluster_id,
         },
     )
+    _, err = capsys.readouterr()
+    assert (
+        "The consumers list command is deprecated and will be removed in the future."
+        in err
+    )
 
 
 @mock.patch.object(Client, "request", return_value=({}, None))
-def test_consumers_edit(mock_request):
+def test_consumers_edit(mock_request, capsys):
     consumer_id = gen_uuid()
     cluster_id = gen_uuid()
 
@@ -164,6 +174,11 @@ def test_consumers_edit(mock_request):
             "table_schema": "doc",
         },
     )
+    _, err = capsys.readouterr()
+    assert (
+        "The consumers edit command is deprecated and will be removed in the future."
+        in err
+    )
 
 
 @mock.patch.object(Client, "request", return_value=(None, {}))
@@ -179,6 +194,10 @@ def test_consumers_delete(mock_request, capsys):
     _, err_output = capsys.readouterr()
     assert "Success" in err_output
     assert "Consumer deleted." in err_output
+    assert (
+        "The consumers delete command is deprecated and will be removed in the future."
+        in err_output
+    )
 
 
 @mock.patch.object(Client, "request", return_value=(None, {}))
@@ -192,6 +211,10 @@ def test_consumers_delete_flag(mock_request, capsys):
     _, err_output = capsys.readouterr()
     assert "Success" in err_output
     assert "Consumer deleted." in err_output
+    assert (
+        "The consumers delete command is deprecated and will be removed in the future."
+        in err_output
+    )
 
 
 @mock.patch.object(Client, "request", return_value=(None, {}))


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement


## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
