### PR TITLE
Add --idp argument for login

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for croud
 Unreleased
 ==========
 
+- Added support for choosing the identity provider for the login via the
+  optional ``--idp`` argument.
+
 0.24.0 - 2020/09/08
 ===================
 

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -96,7 +96,17 @@ command_tree = {
             },
         }
     },
-    "login": {"help": "Log in to CrateDB Cloud.", "resolver": login},
+    "login": {
+        "help": "Log in to CrateDB Cloud.",
+        "resolver": login,
+        "extra_args": [
+            Argument(
+                "--idp", type=str, required=False,
+                choices={"cognito", "azuread"},
+                help="The identity provider (IdP) for the login."
+            ),
+        ],
+    },
     "logout": {"help": "Log out of CrateDB Cloud.", "resolver": logout},
     "config": {
         "help": "Manage croud configuration.",

--- a/croud/login.py
+++ b/croud/login.py
@@ -26,7 +26,10 @@ from croud.printer import print_error, print_info, print_warning
 from croud.server import Server
 from croud.util import can_launch_browser, open_page_in_browser
 
-LOGIN_PATH = "/oauth2/login?cli=true"
+
+def login_path(idp: str = None) -> str:
+    extra_part = f"{idp}/" if idp else ""
+    return f"/oauth2/{extra_part}login?cli=true"
 
 
 def get_org_id() -> Optional[str]:
@@ -48,7 +51,7 @@ def login(args: Namespace) -> None:
 
     server = Server(CONFIG.set_current_auth_token).start_in_background()
 
-    open_page_in_browser(CONFIG.endpoint + LOGIN_PATH)
+    open_page_in_browser(CONFIG.endpoint + login_path(args.idp))
     print_info("A browser tab has been launched for you to login.")
     try:
         # Wait for the user to login. They'll be redirected to the `SetTokenHandler`

--- a/docs/commands/authentication.rst
+++ b/docs/commands/authentication.rst
@@ -28,6 +28,10 @@ screen.
    Your access token is cached locally, and all subsequent commands will be
    authenticated until you explicitly log out.
 
+CrateDB Cloud offers two authentication methods: username and password (via
+Amazon Cognito) and Azure AD login. By default username and password
+authentication is used, but the login provider can be changed using the
+``--idp`` (IdentityProvider) argument.
 
 .. _logout:
 

--- a/tests/commands/test_login.py
+++ b/tests/commands/test_login.py
@@ -21,7 +21,7 @@ from unittest import mock
 
 import pytest
 
-from croud.login import get_org_id
+from croud.login import get_org_id, login_path
 from croud.server import Server
 from tests.util import call_command
 
@@ -70,3 +70,11 @@ def test_get_org_id(org_id_param, config):
     ):
         org_id = get_org_id()
     assert org_id == org_id_param
+
+
+@pytest.mark.parametrize(
+    "idp,expected",
+    [(None, "/oauth2/login?cli=true"), ("idp", "/oauth2/idp/login?cli=true")],
+)
+def test_login_path(idp, expected):
+    assert login_path(idp) == expected


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

CrateDB Cloud allows two different authentication methods via two
different providers at the moment:

* username + password via Amazon Cognito
* OAuth via Azure Active Directory

The optional `--idp` argument allows for choosing the identity provider
for the login. It defaults to username+password via Cognito (which was
the only possible way up to now).


## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
