### PR TITLE
Support for wide tabular output format, where all fields are displayed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for croud
 Unreleased
 ==========
 
+- Implemented support for wide tabular output format, where all fields are
+  displayed.
+
 - Removed the already deprecated ``croud consumers`` commands.
 
 - Added support for choosing the identity provider for the login via the

--- a/croud/config/schemas.py
+++ b/croud/config/schemas.py
@@ -21,7 +21,7 @@ from marshmallow import Schema, fields, post_load
 from marshmallow.exceptions import ValidationError
 from marshmallow.validate import OneOf
 
-OUTPUT_FORMATS = ("table", "json", "yaml")  # we want to keep them sorted!
+OUTPUT_FORMATS = ("table", "wide", "json", "yaml")  # we want to keep them sorted!
 
 
 class ProfileSchema(Schema):

--- a/croud/organizations/auditlogs/commands.py
+++ b/croud/organizations/auditlogs/commands.py
@@ -36,7 +36,7 @@ iso8601_datetime_re = re.compile(
 )
 
 
-def actor_id_transfor(field):
+def actor_id_transform(field):
     return field["id"] or "SYSTEM"
 
 
@@ -80,5 +80,5 @@ def auditlogs_list(args: Namespace) -> None:
         errors=errors,
         keys=["action", "actor", "created"],
         output_fmt=get_output_format(args),
-        transforms=[None, actor_id_transfor, None],
+        transforms={"actor": actor_id_transform},
     )

--- a/croud/organizations/users/commands.py
+++ b/croud/organizations/users/commands.py
@@ -67,7 +67,7 @@ def org_users_list(args: Namespace) -> None:
         errors=errors,
         output_fmt=get_output_format(args),
         keys=["uid", "email", "username", "organization_roles"],
-        transforms=[None, None, None, role_fqn_transform],
+        transforms={"organization_roles": role_fqn_transform},
     )
 
 

--- a/croud/projects/users/commands.py
+++ b/croud/projects/users/commands.py
@@ -65,7 +65,7 @@ def project_users_list(args: Namespace) -> None:
         errors=errors,
         output_fmt=get_output_format(args),
         keys=["uid", "email", "username", "project_roles"],
-        transforms=[None, None, None, role_fqn_transform],
+        transforms={"project_roles": role_fqn_transform},
     )
 
 

--- a/croud/users/commands.py
+++ b/croud/users/commands.py
@@ -48,11 +48,8 @@ def users_list(args: Namespace) -> None:
         errors=errors,
         output_fmt=get_output_format(args),
         keys=["uid", "email", "username", "organization_roles", "project_roles"],
-        transforms=[
-            None,
-            None,
-            None,
-            transform_roles_list("organization_id"),
-            transform_roles_list("project_id"),
-        ],
+        transforms={
+            "organization_roles": transform_roles_list("organization_id"),
+            "project_roles": transform_roles_list("project_id"),
+        },
     )

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -51,8 +51,9 @@ The keys have the following meaning:
 :``default-format``:
 
     The default output format for API requests. This can be either ``table``
-    (default), ``json``, or ``yaml``. This value is only used if the current
-    profile does not specify a ``format``.
+    (default, displays the most important fields), ``wide`` (a table format
+    displaying all fields), ``json``, or ``yaml``. This value is only used if
+    the current profile does not specify a ``format``.
 
 :``profiles``:
 

--- a/tests/test_config_schemas.py
+++ b/tests/test_config_schemas.py
@@ -75,7 +75,7 @@ def test_load_profile_schema_valid(data):
     endpoint: http://localhost:8000
     format: invalid
     """,
-            {"format": ["Must be one of: table, json, yaml."]},
+            {"format": ["Must be one of: table, wide, json, yaml."]},
         ),
     ],
 )


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

`-o wide` can be used to print the full table as opposed to the cherry picked columns the argument `-o table` provides.

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
