### PR TITLE
Added an (optional) region param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.python-version
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Changes for croud
 Unreleased
 ==========
 
+- Added the ``region`` parameter to profiles in the config file.
+  This makes it explicit which one is being used as the recommended API endpoint
+  is always ``https://console.cratedb.cloud``.
+
 0.25.0 - 2020/11/30
 ===================
 

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -146,6 +146,10 @@ command_tree = {
                                 "--format", type=str, required=False,
                                 help="The output format for the profile."
                             ),
+                            Argument(
+                                "--region", type=str, required=False,
+                                help="The region for the profile."
+                            ),
                         ],
                     },
                     "remove": {

--- a/croud/api.py
+++ b/croud/api.py
@@ -93,7 +93,7 @@ class Client:
             CONFIG.endpoint,
             token=CONFIG.token,
             on_token=CONFIG.set_current_auth_token,
-            region=args.region if args.region is not None else CONFIG.region,
+            region=args.region or CONFIG.region,
             sudo=args.sudo,
         )
 

--- a/croud/api.py
+++ b/croud/api.py
@@ -93,7 +93,7 @@ class Client:
             CONFIG.endpoint,
             token=CONFIG.token,
             on_token=CONFIG.set_current_auth_token,
-            region=args.region,
+            region=args.region if args.region is not None else CONFIG.region,
             sudo=args.sudo,
         )
 

--- a/croud/config/commands.py
+++ b/croud/config/commands.py
@@ -30,6 +30,8 @@ def config_add_profile(args: Namespace) -> None:
     kwargs = {}
     if args.format:
         kwargs["format"] = args.format
+    if args.region:
+        kwargs["region"] = args.region
     try:
         CONFIG.add_profile(args.profile, endpoint=args.endpoint, **kwargs)
     except InvalidProfile:

--- a/croud/config/configuration.py
+++ b/croud/config/configuration.py
@@ -30,20 +30,20 @@ from croud.config.types import ConfigurationType, ProfileType
 
 DEFAULT_CONFIGURATION = """\
 default-format: table
-current-profile: bregenz.a1
+current-profile: aks1.westeurope.azure
 profiles:
-  bregenz.a1:
+  aks1.eastus2.azure:
     auth-token: NULL
-    endpoint: https://bregenz.a1.cratedb.cloud
-    format: table
-  eastus2.azure:
+    endpoint: https://console.cratedb.cloud
+    region: aks1.eastus2.azure
+  aks1.westeurope.azure:
     auth-token: NULL
-    endpoint: https://eastus2.azure.cratedb.cloud
-    format: table
-  westeurope.azure:
+    endpoint: https://console.cratedb.cloud
+    region: aks1.westeurope.azure
+  eks1.eu-west-1.aws:
     auth-token: NULL
-    endpoint: https://westeurope.azure.cratedb.cloud
-    format: table
+    endpoint: https://console.cratedb.cloud
+    region: eks1.eu-west-1.aws
 """
 
 
@@ -96,6 +96,10 @@ class Configuration:
     @property
     def token(self) -> Optional[str]:
         return self.profile["auth-token"]  # type: ignore
+
+    @property
+    def region(self) -> Optional[str]:
+        return self.profile.get("region", None)  # type: ignore
 
     @property
     def organization(self) -> Optional[str]:

--- a/croud/config/schemas.py
+++ b/croud/config/schemas.py
@@ -37,6 +37,7 @@ class ProfileSchema(Schema):
     organization_id = fields.String(
         attribute="organization-id", data_key="organization-id", allow_none=True
     )
+    region = fields.String(required=False)
 
 
 class ConfigSchema(Schema):

--- a/croud/login.py
+++ b/croud/login.py
@@ -33,7 +33,7 @@ def login_path(idp: str = None) -> str:
 
 
 def get_org_id() -> Optional[str]:
-    client = Client(CONFIG.endpoint, token=CONFIG.token)
+    client = Client(CONFIG.endpoint, token=CONFIG.token, region=CONFIG.region)
     data, error = client.get("/api/v2/users/me/")
     if data and not error:
         return data.get("organization_id")

--- a/docs/commands/regions.rst
+++ b/docs/commands/regions.rst
@@ -15,7 +15,9 @@ Print the available regions to the user:
 
 .. note::
 
-   Listed region names can used in the ``--region`` argument to list/deploy resources in that region.
+   The region is specified for each profile in the :doc:`../configuration` file.
+   The region for specific actions can be overridden using the ``--region`` argument to list/deploy resources in that region.
+
 
 Example
 =======
@@ -23,11 +25,11 @@ Example
 .. code-block:: console
 
    sh$ croud regions list
-   +---------------------------+--------------------+
-   | description               | name               |
-   |---------------------------+--------------------|
-   | Bregenz                   | bregenz.a1         |
-   | Azure East-US-2           | eastus2.azure      |
-   | AWS West Europe (Ireland) | eks1.eu-west-1.aws |
-   | Azure West-Europe         | westeurope.azure   |
-   +---------------------------+--------------------+
+   +--------------------------------+-----------------------+
+   | description                    | name                  |
+   |--------------------------------+-----------------------|
+   | Azure East US 2                | aks1.eastus2.azure    |
+   | Azure West Europe              | aks1.westeurope.azure |
+   | AWS West Europe (Ireland)      | eks1.eu-west-1.aws    |
+   +--------------------------------+-----------------------+
+

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -21,21 +21,21 @@ The contents of the configuration file of a fresh ``croud`` installation are
 
 .. code-block:: yaml
 
-   current-profile: dev
+   current-profile: aks1.westeurope.azure
    default-format: table
    profiles:
-     bregenz.a1:
+     aks1.eastus2.azure:
        auth-token: NULL
-       endpoint: https://bregenz.a1.cratedb.cloud
-       format: table
-     eastus2.azure:
-       auth-token: null
-       endpoint: https://eastus2.azure.cratedb.cloud
-       format: table
-     westeurope.azure:
-       auth-token: null
-       endpoint: https://westeurope.azure.cratedb.cloud
-       format: table
+       endpoint: https://console.cratedb.cloud
+       region: aks1.eastus2.azure
+     aks1.westeurope.azure:
+       auth-token: NULL
+       endpoint: https://console.cratedb.cloud
+       region: aks1.westeurope.azure
+     eks1.eu-west-1.aws:
+       auth-token: NULL
+       endpoint: https://console.cratedb.cloud
+       region: eks1.eu-west-1.aws
 
 
 Configuration file keys
@@ -59,11 +59,13 @@ The keys have the following meaning:
 
     A dictionary of available profiles. There are three default profiles available
     (see :ref:`available-profiles`).
-    Each profile consists of ``auth-token``, ``endpoint``, and ``format``.
+    Each profile consists of ``auth-token``, ``endpoint``, ``region``, and ``format``.
 
     ``auth-token`` is populated with the API token upon login.
 
     ``endpoint`` is the full URL of the API endpoint that is used for requests.
+
+    ``region`` is the specific region where CrateDB Cloud resources are accessed in.
 
     ``format`` is the output format for this profile. This key is optional and
     if it is missing, the output format will fall back on ``default-format``.
@@ -84,13 +86,15 @@ details.
 Available profiles
 ==================
 
-==================== ====================================== ===========
-Profile              Endpoint                               Format
-==================== ====================================== ===========
-bregenz.a1           https://bregenz.a1.cratedb.cloud       table
-eastus2.azure        https://eastus2.azure.cratedb.cloud    table
-westeurope.azure     https://westeurope.azure.cratedb.cloud table
-==================== ====================================== ===========
+The API Endpoint for all profiles is ``https://console.cratedb.cloud``
+
+========================== ====================================== ===========
+Profile                    Region                                 Format
+========================== ====================================== ===========
+aks1.eastus2.azure         aks1.eastus2.azure                     table
+aks1.westeurope.azure      aks1.westeurope.azure                  table
+eks1.eu-west-1.aws         eks1.eu-west-1.aws                     table
+========================== ====================================== ===========
 
 
 Incompatible versions

--- a/tests/commands/test_config.py
+++ b/tests/commands/test_config.py
@@ -37,8 +37,11 @@ def test_config_add_profile(config, capsys):
         "new-profile",
         "--endpoint",
         "http://localhost:8000",
+        "--region",
+        "new-region",
     )
     assert "format" not in config.profiles["new-profile"]
+    assert config.profiles["new-profile"]["region"] == "new-region"
 
     _, err = capsys.readouterr()
     assert "Added profile 'new-profile'" in err
@@ -55,6 +58,7 @@ def test_config_add_profile(config, capsys):
         "json",
     )
     assert config.profiles["newer-profile"]["format"] == "json"
+    assert "region" not in config.profiles["newer-profile"]
 
     _, err = capsys.readouterr()
     assert "Added profile 'newer-profile'" in err
@@ -67,13 +71,13 @@ def test_config_add_duplicate_profile(config, capsys):
             "config",
             "profiles",
             "add",
-            "bregenz.a1",
+            "aks1.westeurope.azure",
             "--endpoint",
             "http://localhost:8000",
         )
     assert exc_info.value.code == 1
     _, err = capsys.readouterr()
-    assert "Failed to add profile 'bregenz.a1'" in err
+    assert "Failed to add profile 'aks1.westeurope.azure'" in err
 
 
 def test_config_current_profile(config, capsys):
@@ -83,11 +87,11 @@ def test_config_current_profile(config, capsys):
 
 
 def test_config_remove_profile(config, capsys):
-    call_command("croud", "config", "profiles", "remove", "bregenz.a1")
-    assert "bregenz.a1" not in config.profiles
+    call_command("croud", "config", "profiles", "remove", "aks1.westeurope.azure")
+    assert "aks1.westeurope.azure" not in config.profiles
 
     _, err = capsys.readouterr()
-    assert "Removed profile 'bregenz.a1'" in err
+    assert "Removed profile 'aks1.westeurope.azure'" in err
 
 
 def test_config_remove_current_profile(config, capsys):
@@ -101,12 +105,12 @@ def test_config_remove_current_profile(config, capsys):
 
 
 def test_config_set_profile(config, capsys):
-    assert config.name != "bregenz.a1"
-    call_command("croud", "config", "profiles", "use", "bregenz.a1")
-    assert config.name == "bregenz.a1"
+    assert config.name != "aks1.westeurope.azure"
+    call_command("croud", "config", "profiles", "use", "aks1.westeurope.azure")
+    assert config.name == "aks1.westeurope.azure"
 
     _, err = capsys.readouterr()
-    assert "Switched to profile 'bregenz.a1'" in err
+    assert "Switched to profile 'aks1.westeurope.azure'" in err
 
 
 def test_config_set_profile_does_not_exist(config, capsys):

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -84,12 +84,13 @@ def test_default_configuration_instance(tmp_path):
     ):
         config = Configuration("test.yaml")
         assert config._file_path == tmp_path / "test.yaml"
-        assert "bregenz.a1" in config.profiles
-        assert "eastus2.azure" in config.profiles
-        assert "westeurope.azure" in config.profiles
-        assert config.name == "bregenz.a1"
+        assert "aks1.westeurope.azure" in config.profiles
+        assert "aks1.eastus2.azure" in config.profiles
+        assert "eks1.eu-west-1.aws" in config.profiles
+        assert config.name == "aks1.westeurope.azure"
         assert config.token is None
-        assert config.endpoint == "https://bregenz.a1.cratedb.cloud"
+        assert config.endpoint == "https://console.cratedb.cloud"
+        assert config.region == "aks1.westeurope.azure"
         assert config.format == "table"
         assert config.organization is None
 
@@ -126,8 +127,8 @@ default-format: table
 
 
 def test_use_profile(config):
-    config.use_profile("westeurope.azure")
-    assert config.name == config.config["current-profile"] == "westeurope.azure"
+    config.use_profile("aks1.westeurope.azure")
+    assert config.name == config.config["current-profile"] == "aks1.westeurope.azure"
 
 
 def test_add_profile(config):
@@ -142,12 +143,12 @@ def test_add_profile(config):
 
 def test_add_profile_duplicate(config):
     with pytest.raises(InvalidProfile):
-        config.add_profile("bregenz.a1", endpoint="http://localhost:8000")
+        config.add_profile("aks1.eastus2.azure", endpoint="http://localhost:8000")
 
 
 def test_remove_profile(config):
-    config.remove_profile("eastus2.azure")
-    assert "eastus2.azure" not in config.config["profiles"]
+    config.remove_profile("aks1.eastus2.azure")
+    assert "aks1.eastus2.azure" not in config.config["profiles"]
 
 
 def test_remove_profile_does_not_exist(config):


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This allows us to set a default region (which can also be __any__) and not have to ever specify one when running any commands.


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
