### PR TITLE
Get resources by their ID

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Changes for croud
 Unreleased
 ==========
 
+- Added new subcommand ``get`` for the resources ``clusters``,
+  ``organizations``, ``projects``, ``subscriptions`` that returns a single item
+  of the requested resource by its ID.
+
 - Added the ``region`` parameter to profiles in the config file.
   This makes it explicit which one is being used as the recommended API endpoint
   is always ``https://console.cratedb.cloud``.

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -26,6 +26,7 @@ import colorama
 from croud.clusters.commands import (
     clusters_delete,
     clusters_deploy,
+    clusters_get,
     clusters_list,
     clusters_scale,
     clusters_upgrade,
@@ -46,6 +47,7 @@ from croud.organizations.commands import (
     organizations_create,
     organizations_delete,
     organizations_edit,
+    organizations_get,
     organizations_list,
 )
 from croud.organizations.users.commands import (
@@ -60,6 +62,7 @@ from croud.projects.commands import (
     project_create,
     project_delete,
     project_edit,
+    projects_get,
     projects_list,
 )
 from croud.projects.users.commands import (
@@ -68,7 +71,7 @@ from croud.projects.users.commands import (
     project_users_remove,
 )
 from croud.regions import regions_list
-from croud.subscriptions.commands import subscriptions_list
+from croud.subscriptions.commands import subscriptions_get, subscriptions_list
 from croud.users.commands import users_list
 from croud.users.roles.commands import roles_list
 
@@ -209,6 +212,18 @@ command_tree = {
                 ],
                 "resolver": project_edit,
             },
+            "get": {
+                "help": (
+                    "Get a project by its ID."
+                ),
+                "extra_args": [
+                    Argument(
+                        "id", type=str,
+                        help="The ID of the project.",
+                    ),
+                ],
+                "resolver": projects_get,
+            },
             "list": {
                 "help": (
                     "List all projects the current user has access to in "
@@ -271,6 +286,18 @@ command_tree = {
     "clusters": {
         "help": "Manage clusters.",
         "commands": {
+            "get": {
+                "help": (
+                    "Get a cluster by its ID."
+                ),
+                "extra_args": [
+                    Argument(
+                        "id", type=str,
+                        help="The ID of the cluster.",
+                    ),
+                ],
+                "resolver": clusters_get,
+            },
             "list": {
                 "help": "List all clusters the current user has access to.",
                 "extra_args": [
@@ -397,6 +424,18 @@ command_tree = {
                     ),
                 ],
                 "resolver": organizations_create,
+            },
+            "get": {
+                "help": (
+                    "Get an organization by its ID."
+                ),
+                "extra_args": [
+                    Argument(
+                        "id", type=str,
+                        help="The ID of the organization.",
+                    ),
+                ],
+                "resolver": organizations_get,
             },
             "list": {
                 "help": "List all organizations the current user has access to.",
@@ -552,6 +591,18 @@ command_tree = {
     "subscriptions": {
         "help": "Manage subscriptions.",
         "commands": {
+            "get": {
+                "help": (
+                    "Get a subscription by its ID."
+                ),
+                "extra_args": [
+                    Argument(
+                        "id", type=str,
+                        help="The ID of the subscription.",
+                    ),
+                ],
+                "resolver": subscriptions_get,
+            },
             "list": {
                 "help": "List all subscriptions the current user has access to.",
                 "resolver": subscriptions_list,

--- a/croud/clusters/commands.py
+++ b/croud/clusters/commands.py
@@ -25,6 +25,18 @@ from croud.printer import print_response
 from croud.util import require_confirmation
 
 
+def clusters_get(args: Namespace) -> None:
+    """
+    Get cluster by ID
+    """
+
+    client = Client.from_args(args)
+    data, errors = client.get(f"/api/v2/clusters/{args.id}/")
+    print_response(
+        data=data, errors=errors, output_fmt=get_output_format(args),
+    )
+
+
 def clusters_list(args: Namespace) -> None:
     """
     Lists all projects for the current user in the specified region

--- a/croud/clusters/commands.py
+++ b/croud/clusters/commands.py
@@ -26,10 +26,6 @@ from croud.util import require_confirmation
 
 
 def clusters_get(args: Namespace) -> None:
-    """
-    Get cluster by ID
-    """
-
     client = Client.from_args(args)
     data, errors = client.get(f"/api/v2/clusters/{args.id}/")
     print_response(
@@ -38,10 +34,6 @@ def clusters_get(args: Namespace) -> None:
 
 
 def clusters_list(args: Namespace) -> None:
-    """
-    Lists all projects for the current user in the specified region
-    """
-
     params = {}
     if args.project_id:
         params["project_id"] = args.project_id
@@ -66,10 +58,6 @@ def clusters_list(args: Namespace) -> None:
 
 
 def clusters_deploy(args: Namespace) -> None:
-    """
-    Deploys a new CrateDB cluster.
-    """
-
     body = {
         "crate_version": args.version,
         "name": args.cluster_name,
@@ -96,10 +84,6 @@ def clusters_deploy(args: Namespace) -> None:
 
 
 def clusters_scale(args: Namespace) -> None:
-    """
-    Scale an existing CrateDB cluster.
-    """
-
     body = {"product_unit": args.unit}
     client = Client.from_args(args)
     data, errors = client.put(f"/api/v2/clusters/{args.cluster_id}/scale/", body=body)
@@ -115,10 +99,6 @@ def clusters_scale(args: Namespace) -> None:
 
 
 def clusters_upgrade(args: Namespace) -> None:
-    """
-    Upgrade an existing CrateDB Cluster to a later version.
-    """
-
     body = {"crate_version": args.version}
     client = Client.from_args(args)
     data, errors = client.put(f"/api/v2/clusters/{args.cluster_id}/upgrade/", body=body)

--- a/croud/organizations/auditlogs/commands.py
+++ b/croud/organizations/auditlogs/commands.py
@@ -42,10 +42,6 @@ def actor_id_transform(field):
 
 @org_id_config_fallback
 def auditlogs_list(args: Namespace) -> None:
-    """
-    Lists all auditlogs within an organization
-    """
-
     client = Client.from_args(args)
     url = f"/api/v2/organizations/{args.org_id}/auditlogs/"
     data: List[Dict] = []

--- a/croud/organizations/commands.py
+++ b/croud/organizations/commands.py
@@ -26,10 +26,6 @@ from croud.util import org_id_config_fallback, require_confirmation
 
 
 def organizations_create(args: Namespace) -> None:
-    """
-    Creates an organization
-    """
-
     client = Client.from_args(args)
     if args.plan_type:
         body = {"name": args.name, "plan_type": args.plan_type}
@@ -48,10 +44,6 @@ def organizations_create(args: Namespace) -> None:
 
 @org_id_config_fallback
 def organizations_edit(args: Namespace) -> None:
-    """
-    Edit an organization
-    """
-
     client = Client.from_args(args)
     body = {}
     if args.plan_type:
@@ -73,10 +65,6 @@ def organizations_edit(args: Namespace) -> None:
 
 
 def organizations_get(args: Namespace) -> None:
-    """
-    Get organization by ID
-    """
-
     client = Client.from_args(args)
     data, errors = client.get(f"/api/v2/organizations/{args.id}/")
     print_response(
@@ -85,10 +73,6 @@ def organizations_get(args: Namespace) -> None:
 
 
 def organizations_list(args: Namespace) -> None:
-    """
-    Lists organizations
-    """
-
     client = Client.from_args(args)
     data, errors = client.get("/api/v2/organizations/")
     print_response(
@@ -105,10 +89,6 @@ def organizations_list(args: Namespace) -> None:
     cancel_msg="Organization deletion cancelled.",
 )
 def organizations_delete(args: Namespace) -> None:
-    """
-    Delete an organization
-    """
-
     client = Client.from_args(args)
     data, errors = client.delete(f"/api/v2/organizations/{args.org_id}/")
     print_response(

--- a/croud/organizations/commands.py
+++ b/croud/organizations/commands.py
@@ -72,6 +72,18 @@ def organizations_edit(args: Namespace) -> None:
     )
 
 
+def organizations_get(args: Namespace) -> None:
+    """
+    Get organization by ID
+    """
+
+    client = Client.from_args(args)
+    data, errors = client.get(f"/api/v2/organizations/{args.id}/")
+    print_response(
+        data=data, errors=errors, output_fmt=get_output_format(args),
+    )
+
+
 def organizations_list(args: Namespace) -> None:
     """
     Lists organizations

--- a/croud/organizations/users/commands.py
+++ b/croud/organizations/users/commands.py
@@ -31,7 +31,6 @@ from croud.util import org_id_config_fallback
 @org_id_config_fallback
 def org_users_add(args: Namespace):
     client = Client.from_args(args)
-
     data, errors = client.post(
         f"/api/v2/organizations/{args.org_id}/users/",
         body={"user": args.user, "role_fqn": args.role},
@@ -56,10 +55,6 @@ def role_fqn_transform(field):
 
 @org_id_config_fallback
 def org_users_list(args: Namespace) -> None:
-    """
-    Lists organization users
-    """
-
     client = Client.from_args(args)
     data, errors = client.get(f"/api/v2/organizations/{args.org_id}/users/")
     print_response(
@@ -74,7 +69,6 @@ def org_users_list(args: Namespace) -> None:
 @org_id_config_fallback
 def org_users_remove(args: Namespace):
     client = Client.from_args(args)
-
     data, errors = client.delete(
         f"/api/v2/organizations/{args.org_id}/users/{args.user}/"
     )

--- a/croud/products/commands.py
+++ b/croud/products/commands.py
@@ -25,10 +25,6 @@ from croud.printer import print_response
 
 
 def products_list(args: Namespace) -> None:
-    """
-    Lists available products
-    """
-
     client = Client.from_args(args)
     url = "/api/v2/products/"
     data, errors = client.get(url, params={"kind": args.kind} if args.kind else None)

--- a/croud/projects/commands.py
+++ b/croud/projects/commands.py
@@ -27,10 +27,6 @@ from croud.util import org_id_config_fallback, require_confirmation
 
 @org_id_config_fallback
 def project_create(args: Namespace) -> None:
-    """
-    Creates a project in the organization the user belongs to.
-    """
-
     client = Client.from_args(args)
     data, errors = client.post(
         "/api/v2/projects/", body={"name": args.name, "organization_id": args.org_id}
@@ -49,9 +45,6 @@ def project_create(args: Namespace) -> None:
     cancel_msg="Project deletion cancelled.",
 )
 def project_delete(args: Namespace) -> None:
-    """
-    Deletes a project in the organization the user belongs to.
-    """
     client = Client.from_args(args)
     data, errors = client.delete(f"/api/v2/projects/{args.project_id}/")
     print_response(
@@ -63,10 +56,6 @@ def project_delete(args: Namespace) -> None:
 
 
 def project_edit(args: Namespace) -> None:
-    """
-    Rename a specified project.
-    """
-
     client = Client.from_args(args)
     body = {}
     if args.name:
@@ -86,10 +75,6 @@ def project_edit(args: Namespace) -> None:
 
 
 def projects_get(args: Namespace) -> None:
-    """
-    Get project by ID
-    """
-
     client = Client.from_args(args)
     data, errors = client.get(f"/api/v2/projects/{args.id}/")
     print_response(
@@ -98,10 +83,6 @@ def projects_get(args: Namespace) -> None:
 
 
 def projects_list(args: Namespace) -> None:
-    """
-    Lists all projects for the current user in the specified region
-    """
-
     client = Client.from_args(args)
     data, errors = client.get("/api/v2/projects/")
     print_response(

--- a/croud/projects/commands.py
+++ b/croud/projects/commands.py
@@ -85,6 +85,18 @@ def project_edit(args: Namespace) -> None:
     )
 
 
+def projects_get(args: Namespace) -> None:
+    """
+    Get project by ID
+    """
+
+    client = Client.from_args(args)
+    data, errors = client.get(f"/api/v2/projects/{args.id}/")
+    print_response(
+        data=data, errors=errors, output_fmt=get_output_format(args),
+    )
+
+
 def projects_list(args: Namespace) -> None:
     """
     Lists all projects for the current user in the specified region

--- a/croud/projects/users/commands.py
+++ b/croud/projects/users/commands.py
@@ -25,10 +25,6 @@ from croud.printer import print_response
 
 
 def project_users_add(args: Namespace) -> None:
-    """
-    Adds a user to a project.
-    """
-
     client = Client.from_args(args)
 
     data, errors = client.post(
@@ -54,10 +50,6 @@ def role_fqn_transform(field):
 
 
 def project_users_list(args: Namespace) -> None:
-    """
-    Lists project users
-    """
-
     client = Client.from_args(args)
     data, errors = client.get(f"/api/v2/projects/{args.project_id}/users/")
     print_response(
@@ -70,10 +62,6 @@ def project_users_list(args: Namespace) -> None:
 
 
 def project_users_remove(args: Namespace) -> None:
-    """
-    Removes a user from a project.
-    """
-
     client = Client.from_args(args)
     data, errors = client.delete(
         f"/api/v2/projects/{args.project_id}/users/{args.user}/"

--- a/croud/subscriptions/commands.py
+++ b/croud/subscriptions/commands.py
@@ -25,9 +25,6 @@ from croud.printer import print_response
 
 
 def subscriptions_get(args: Namespace) -> None:
-    """
-    Get subscription by ID
-    """
     client = Client.from_args(args)
     data, errors = client.get(f"/api/v2/subscriptions/{args.id}/")
     print_response(
@@ -36,9 +33,6 @@ def subscriptions_get(args: Namespace) -> None:
 
 
 def subscriptions_list(args: Namespace) -> None:
-    """
-    Lists all subscriptions for the current user in the organization
-    """
     client = Client.from_args(args)
     data, errors = client.get("/api/v2/subscriptions/")
     print_response(

--- a/croud/subscriptions/commands.py
+++ b/croud/subscriptions/commands.py
@@ -24,6 +24,17 @@ from croud.config import get_output_format
 from croud.printer import print_response
 
 
+def subscriptions_get(args: Namespace) -> None:
+    """
+    Get subscription by ID
+    """
+    client = Client.from_args(args)
+    data, errors = client.get(f"/api/v2/subscriptions/{args.id}/")
+    print_response(
+        data=data, errors=errors, output_fmt=get_output_format(args),
+    )
+
+
 def subscriptions_list(args: Namespace) -> None:
     """
     Lists all subscriptions for the current user in the organization

--- a/croud/users/commands.py
+++ b/croud/users/commands.py
@@ -32,9 +32,6 @@ def transform_roles_list(key):
 
 
 def users_list(args: Namespace) -> None:
-    """
-    List all users
-    """
     client = Client.from_args(args)
     if args.no_org:
         print_warning(

--- a/croud/users/roles/commands.py
+++ b/croud/users/roles/commands.py
@@ -25,10 +25,6 @@ from croud.printer import print_response
 
 
 def roles_list(args: Namespace) -> None:
-    """
-    Lists all roles a user can be assigned to
-    """
-
     client = Client.from_args(args)
     data, errors = client.get("/api/v2/roles/")
     print_response(

--- a/tests/commands/test_clusters.py
+++ b/tests/commands/test_clusters.py
@@ -17,6 +17,7 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+import uuid
 from unittest import mock
 
 import pytest
@@ -31,6 +32,13 @@ pytestmark = pytest.mark.usefixtures("config")
 def test_clusers_list(mock_request):
     call_command("croud", "clusters", "list")
     assert_rest(mock_request, RequestMethod.GET, "/api/v2/clusters/", params={})
+
+
+@mock.patch.object(Client, "request", return_value=({}, None))
+def test_clusers_get(mock_request):
+    id = str(uuid.uuid4())
+    call_command("croud", "clusters", "get", id)
+    assert_rest(mock_request, RequestMethod.GET, f"/api/v2/clusters/{id}/")
 
 
 @mock.patch.object(Client, "request", return_value=({}, None))

--- a/tests/commands/test_organizations.py
+++ b/tests/commands/test_organizations.py
@@ -17,6 +17,7 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+import uuid
 from unittest import mock
 
 import pytest
@@ -132,6 +133,13 @@ def test_organizations_edit_no_arguments(mock_request, capsys):
 def test_organizations_list(mock_request):
     call_command("croud", "organizations", "list")
     assert_rest(mock_request, RequestMethod.GET, "/api/v2/organizations/")
+
+
+@mock.patch.object(Client, "request", return_value=({}, None))
+def test_organizations_get(mock_request):
+    id = str(uuid.uuid4())
+    call_command("croud", "organizations", "get", id)
+    assert_rest(mock_request, RequestMethod.GET, f"/api/v2/organizations/{id}/")
 
 
 @mock.patch.object(Client, "request", return_value=(None, {}))

--- a/tests/commands/test_projects.py
+++ b/tests/commands/test_projects.py
@@ -17,6 +17,7 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+import uuid
 from unittest import mock
 
 import pytest
@@ -95,6 +96,13 @@ def test_projects_delete_aborted(mock_request, capsys):
 def test_projects_list(mock_request):
     call_command("croud", "projects", "list")
     assert_rest(mock_request, RequestMethod.GET, "/api/v2/projects/")
+
+
+@mock.patch.object(Client, "request", return_value=({}, None))
+def test_projects_get(mock_request):
+    id = str(uuid.uuid4())
+    call_command("croud", "projects", "get", id)
+    assert_rest(mock_request, RequestMethod.GET, f"/api/v2/projects/{id}/")
 
 
 @pytest.mark.parametrize(

--- a/tests/commands/test_subscriptions.py
+++ b/tests/commands/test_subscriptions.py
@@ -17,6 +17,7 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+import uuid
 from unittest import mock
 
 from croud.api import Client, RequestMethod
@@ -27,3 +28,10 @@ from tests.util import assert_rest, call_command
 def test_subscriptions_list(mock_request):
     call_command("croud", "subscriptions", "list")
     assert_rest(mock_request, RequestMethod.GET, "/api/v2/subscriptions/")
+
+
+@mock.patch.object(Client, "request", return_value=({}, None))
+def test_subscriptions_get(mock_request):
+    id = str(uuid.uuid4())
+    call_command("croud", "subscriptions", "get", id)
+    assert_rest(mock_request, RequestMethod.GET, f"/api/v2/subscriptions/{id}/")


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This commit adds a new subcommand `get` for the following resources:

* `clusters`
* `organizations`
* `projects`
* `subscriptions`

The command requires a single positional argument `ID` and it returns a
single item of the requested resource by fetching the item by its ID
using the `GET /api/v2/{resource}/{id}/` API endpoints.

Example:

```console
$ croud clusters get 205815c3-230f-442d-99e8-1c34bd717845
...
```