### PR TITLE
Add subcommand to fetch a deployment manifest for an edge region

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,11 @@ Changes for croud
 Unreleased
 ==========
 
+- Added new subcommand ``regions generate-deployment-manifest`` to fetch a deployment
+  manifest for an edge region.
+
 - Added the command ``regions create`` that allows superusers to add new cloud and edge regions.
+
 - Added new subcommand ``get`` for the resources ``clusters``,
   ``organizations``, ``projects``, ``subscriptions`` that returns a single item
   of the requested resource by its ID.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changes for croud
 Unreleased
 ==========
 
+- Added the command ``regions create`` that allows superusers to add new cloud and edge regions.
 - Added new subcommand ``get`` for the resources ``clusters``,
   ``organizations``, ``projects``, ``subscriptions`` that returns a single item
   of the requested resource by its ID.

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -70,7 +70,11 @@ from croud.projects.users.commands import (
     project_users_list,
     project_users_remove,
 )
-from croud.regions import regions_create, regions_list
+from croud.regions.commands import (
+    regions_generate_deployment_manifest,
+    regions_list,
+    regions_create,
+)
 from croud.subscriptions.commands import subscriptions_get, subscriptions_list
 from croud.users.commands import users_list
 from croud.users.roles.commands import roles_list
@@ -583,7 +587,7 @@ command_tree = {
         "help": "Print information about available regions.",
         "commands": {
             "list": {
-                "help": "List all available regions",
+                "help": "List all available regions.",
                 "resolver": regions_list,
             },
             "create": {
@@ -617,7 +621,18 @@ command_tree = {
                         help="The organization ID to use.",
                     ),
                 ],
-            }
+            },
+            "generate-deployment-manifest": {
+                "help": "Generate a deployment manifest for an edge region.",
+                "extra_args": [
+                    Argument("--region-name", type=str, help="", required=True),
+                    Argument(
+                        "--file-name", type=str,
+                        help="The name of the created manifest file.",
+                    ),
+                ],
+                "resolver": regions_generate_deployment_manifest,
+            },
         }
     },
     "subscriptions": {

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -70,7 +70,7 @@ from croud.projects.users.commands import (
     project_users_list,
     project_users_remove,
 )
-from croud.regions import regions_list
+from croud.regions import regions_create, regions_list
 from croud.subscriptions.commands import subscriptions_get, subscriptions_list
 from croud.users.commands import users_list
 from croud.users.roles.commands import roles_list
@@ -586,6 +586,38 @@ command_tree = {
                 "help": "List all available regions",
                 "resolver": regions_list,
             },
+            "create": {
+                "help": "Create a new region.",
+                "resolver": regions_create,
+                "extra_args": [
+                    Argument(
+                        "--aws-bucket", type=str, required=True,
+                        help="The AWS S3 bucket where cluster backups will be stored.",
+                    ),
+                    Argument(
+                        "--aws-region", type=str, required=True,
+                        help="The AWS region where the S3 bucket for cluster"
+                             " backups is expected to be.",
+                    ),
+                    Argument(
+                        "--name", type=str, required=False,
+                        help="The domain name prefix that will be used to reach"
+                             " the region. A Crate domain will be added as a suffix.",
+                    ),
+                    Argument(
+                        "--description", type=str, required=True,
+                        help="The description of the new region.",
+                    ),
+                    Argument(
+                        "--provider", type=str, required=True,
+                        help="Either AWS, EKS or EDGE",
+                    ),
+                    Argument(
+                        "--org-id", type=str, required=False,
+                        help="The organization ID to use.",
+                    ),
+                ],
+            }
         }
     },
     "subscriptions": {

--- a/croud/regions.py
+++ b/croud/regions.py
@@ -53,9 +53,9 @@ def regions_create(args: Namespace) -> None:
 
     # Add optional parameters only when present
     if args.name:
-        body.setdefault("name", args.name)
+        body["name"] = args.name
     if args.org_id:
-        body.setdefault("organization_id", args.org_id)
+        body["organization_id"] = args.org_id
 
     data, errors = client.post("/api/v2/regions/", body=body)
 

--- a/croud/regions.py
+++ b/croud/regions.py
@@ -37,3 +37,31 @@ def regions_list(args: Namespace) -> None:
         keys=["name", "description"],
         output_fmt=get_output_format(args),
     )
+
+
+def regions_create(args: Namespace) -> None:
+    """
+    Creates a new region
+    """
+    client = Client.from_args(args)
+    body = {
+        "aws_bucket": args.aws_bucket,
+        "aws_region": args.aws_region,
+        "description": args.description,
+        "provider": args.provider,
+    }
+
+    # Add optional parameters only when present
+    if args.name:
+        body.setdefault("name", args.name)
+    if args.org_id:
+        body.setdefault("organization_id", args.org_id)
+
+    data, errors = client.post("/api/v2/regions/", body=body)
+
+    print_response(
+        data=data,
+        errors=errors,
+        keys=["name", "description"],
+        output_fmt=get_output_format(args),
+    )

--- a/docs/commands/regions.rst
+++ b/docs/commands/regions.rst
@@ -61,3 +61,23 @@ Example
    |---------------+---------------------------------------------------|
    | Edge region   | 2c0d0e22b0e846b2a7acdcbf092e54a3.edge.cratedb.net |
    +---------------+---------------------------------------------------+
+
+
+``regions generate-deployment-manifest``
+========================================
+
+Generate and fetch a deployment manifest for an edge region:
+
+.. argparse::
+   :module: croud.__main__
+   :func: get_parser
+   :prog: croud
+   :path: regions generate-deployment-manifest
+
+Example
+=======
+
+.. code-block:: console
+
+   sh$ croud regions generate-deployment-manifest --region-name region-name
+   The .yaml manifest as output.

--- a/docs/commands/regions.rst
+++ b/docs/commands/regions.rst
@@ -33,3 +33,31 @@ Example
    | AWS West Europe (Ireland)      | eks1.eu-west-1.aws    |
    +--------------------------------+-----------------------+
 
+
+
+``regions create``
+==================
+
+Creates a new Edge or Cloud region:
+
+.. argparse::
+   :module: croud.__main__
+   :func: get_parser
+   :prog: croud
+   :path: regions create
+
+.. note::
+
+   Only superusers can create regions.
+
+Example
+=======
+
+.. code-block:: console
+
+   sh$ croud regions create --org-id 926d4e6b-5967-4ab4-8f46-82a90150ab31 --description "Edge region" --provider EDGE --aws-bucket backup-bucket --aws-region eu-west-1 --sudo
+   +---------------+---------------------------------------------------+
+   | description   | name                                              |
+   |---------------+---------------------------------------------------|
+   | Edge region   | 2c0d0e22b0e846b2a7acdcbf092e54a3.edge.cratedb.net |
+   +---------------+---------------------------------------------------+

--- a/docs/commands/regions.rst
+++ b/docs/commands/regions.rst
@@ -55,7 +55,7 @@ Example
 
 .. code-block:: console
 
-   sh$ croud regions create --org-id 926d4e6b-5967-4ab4-8f46-82a90150ab31 --description "Edge region" --provider EDGE --aws-bucket backup-bucket --aws-region eu-west-1 --sudo
+   sh$ croud regions create --org-id 11111111-1111-1111-1111-111111111111 --description "Edge region" --provider EDGE --aws-bucket backup-bucket --aws-region eu-west-1 --sudo
    +---------------+---------------------------------------------------+
    | description   | name                                              |
    |---------------+---------------------------------------------------|

--- a/tests/commands/test_regions.py
+++ b/tests/commands/test_regions.py
@@ -110,3 +110,19 @@ def test_regions_create_missing_description(mock_request, capsys):
     mock_request.assert_not_called()
     _, err_output = capsys.readouterr()
     assert "The following arguments are required: --description" in err_output
+
+
+@mock.patch.object(Client, "request", return_value=({}, None))
+def test_get_region_deployment_manifest(mock_request):
+    call_command(
+        "croud",
+        "regions",
+        "generate-deployment-manifest",
+        "--region-name",
+        "region-name",
+    )
+    assert_rest(
+        mock_request,
+        RequestMethod.GET,
+        "/api/v2/regions/region-name/deployment-manifest/",
+    )


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Add subcommand to fetch a deployment manifest for an edge region.

On hold since the backend endpoint is not yet released.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
