### PR TITLE
Fix loading indicator to also disappear if just a message is printed

### DIFF
--- a/croud/printer.py
+++ b/croud/printer.py
@@ -76,18 +76,22 @@ def print_response(
 
 
 def print_error(text: str):
+    HALO.stop()
     print(Fore.RED + "==> Error: " + Style.RESET_ALL + text, file=sys.stderr)
 
 
 def print_info(text: str):
+    HALO.stop()
     print(Fore.CYAN + "==> Info: " + Style.RESET_ALL + text, file=sys.stderr)
 
 
 def print_warning(text: str):
+    HALO.stop()
     print(Fore.YELLOW + "==> Warning: " + Style.RESET_ALL + text, file=sys.stderr)
 
 
 def print_success(text: str):
+    HALO.stop()
     print(Fore.GREEN + "==> Success: " + Style.RESET_ALL + text, file=sys.stderr)
 
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Fix loading indicator also to disappear if just a message is printed.

To avoid something like that, where the loading indicator doesn't disappear after the command has finished:

<img width="1171" alt="Screenshot 2021-02-15 at 11 29 22" src="https://user-images.githubusercontent.com/10163193/107935154-4be9a600-6f81-11eb-845f-45f3d5884d98.png">

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
