### PR TITLE
Add subcommand to fetch a deployment manifest for an edge region

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,11 @@ Changes for croud
 Unreleased
 ==========
 
+- Added new subcommand ``regions generate-deployment-manifest`` to fetch a deployment
+  manifest for an edge region.
+
 - Added the command ``regions create`` that allows superusers to add new cloud and edge regions.
+
 - Added new subcommand ``get`` for the resources ``clusters``,
   ``organizations``, ``projects``, ``subscriptions`` that returns a single item
   of the requested resource by its ID.

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -70,7 +70,11 @@ from croud.projects.users.commands import (
     project_users_list,
     project_users_remove,
 )
-from croud.regions import regions_create, regions_list
+from croud.regions.commands import (
+    regions_generate_deployment_manifest,
+    regions_list,
+    regions_create,
+)
 from croud.subscriptions.commands import subscriptions_get, subscriptions_list
 from croud.users.commands import users_list
 from croud.users.roles.commands import roles_list
@@ -583,7 +587,7 @@ command_tree = {
         "help": "Print information about available regions.",
         "commands": {
             "list": {
-                "help": "List all available regions",
+                "help": "List all available regions.",
                 "resolver": regions_list,
             },
             "create": {
@@ -617,7 +621,18 @@ command_tree = {
                         help="The organization ID to use.",
                     ),
                 ],
-            }
+            },
+            "generate-deployment-manifest": {
+                "help": "Generate a deployment manifest for an edge region.",
+                "extra_args": [
+                    Argument("--region-name", type=str, help="", required=True),
+                    Argument(
+                        "--file-name", type=str,
+                        help="The name of the created manifest file.",
+                    ),
+                ],
+                "resolver": regions_generate_deployment_manifest,
+            },
         }
     },
     "subscriptions": {

--- a/croud/regions/commands.py
+++ b/croud/regions/commands.py
@@ -18,10 +18,11 @@
 # software solely pursuant to the terms of the relevant commercial agreement.
 
 from argparse import Namespace
+from base64 import b64decode
 
 from croud.api import Client
 from croud.config import get_output_format
-from croud.printer import print_response
+from croud.printer import print_error, print_response, print_success
 
 
 def regions_list(args: Namespace) -> None:
@@ -65,3 +66,31 @@ def regions_create(args: Namespace) -> None:
         keys=["name", "description"],
         output_fmt=get_output_format(args),
     )
+
+
+def regions_generate_deployment_manifest(args: Namespace) -> None:
+    """
+    Returns a manifest file that can be used to setup an edge region in
+    a custom kubernetes cluster.
+    """
+
+    client = Client.from_args(args)
+    data, errors = client.get(
+        f"/api/v2/regions/{args.region_name}/deployment-manifest/"
+    )
+    if data:
+        content = b64decode(data["content"]).decode()
+        if args.file_name:
+            try:
+                with open(args.file_name, "x") as file:
+                    file.write(content)
+                    print_success(f"Manifest written to: {args.file_name}")
+            except FileExistsError:
+                print_error(f"The file {args.file_name} already exists.")
+        else:
+            print(content)
+
+    else:
+        print_response(
+            data=data, errors=errors, output_fmt=get_output_format(args),
+        )

--- a/docs/commands/regions.rst
+++ b/docs/commands/regions.rst
@@ -61,3 +61,23 @@ Example
    |---------------+---------------------------------------------------|
    | Edge region   | 2c0d0e22b0e846b2a7acdcbf092e54a3.edge.cratedb.net |
    +---------------+---------------------------------------------------+
+
+
+``regions generate-deployment-manifest``
+========================================
+
+Generate and fetch a deployment manifest for an edge region:
+
+.. argparse::
+   :module: croud.__main__
+   :func: get_parser
+   :prog: croud
+   :path: regions generate-deployment-manifest
+
+Example
+=======
+
+.. code-block:: console
+
+   sh$ croud regions generate-deployment-manifest --region-name region-name
+   The .yaml manifest as output.

--- a/tests/commands/test_regions.py
+++ b/tests/commands/test_regions.py
@@ -110,3 +110,19 @@ def test_regions_create_missing_description(mock_request, capsys):
     mock_request.assert_not_called()
     _, err_output = capsys.readouterr()
     assert "The following arguments are required: --description" in err_output
+
+
+@mock.patch.object(Client, "request", return_value=({}, None))
+def test_get_region_deployment_manifest(mock_request):
+    call_command(
+        "croud",
+        "regions",
+        "generate-deployment-manifest",
+        "--region-name",
+        "region-name",
+    )
+    assert_rest(
+        mock_request,
+        RequestMethod.GET,
+        "/api/v2/regions/region-name/deployment-manifest/",
+    )


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Add subcommand to fetch a deployment manifest for an edge region.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
