### PR TITLE
Remove regions generate manifest command

### DIFF
--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -72,7 +72,6 @@ from croud.projects.users.commands import (
 )
 from croud.regions.commands import (
     regions_create,
-    regions_generate_deployment_manifest,
     regions_list,
 )
 from croud.subscriptions.commands import subscriptions_get, subscriptions_list
@@ -623,18 +622,6 @@ command_tree = {
                     ),
                     Argument("-y", "--yes", action="store_true", default=False),
                 ],
-            },
-            "generate-deployment-manifest": {
-                "help": "Generate a deployment manifest for an edge region.",
-                "extra_args": [
-                    Argument("--region-name", type=str, help="", required=True),
-                    Argument(
-                        "--file-name", type=str,
-                        help="The name of the created manifest file.",
-                    ),
-                    Argument("-y", "--yes", action="store_true", default=False),
-                ],
-                "resolver": regions_generate_deployment_manifest,
             },
         }
     },

--- a/croud/regions/commands.py
+++ b/croud/regions/commands.py
@@ -18,11 +18,10 @@
 # software solely pursuant to the terms of the relevant commercial agreement.
 
 from argparse import Namespace
-from base64 import b64decode
 
 from croud.api import Client
 from croud.config import get_output_format
-from croud.printer import print_error, print_response, print_success
+from croud.printer import print_response, print_success
 from croud.util import require_confirmation
 
 
@@ -94,35 +93,3 @@ def regions_create(args: Namespace) -> None:
                 keys=["token"],
                 output_fmt=get_output_format(args),
             )
-
-
-@require_confirmation(
-    "The generation of a deployment manfiest for an edge region is an experimental feature. Do you really want to use it?",  # noqa
-    cancel_msg="Deployment manifest generation cancelled.",
-)
-def regions_generate_deployment_manifest(args: Namespace) -> None:
-    """
-    Returns a manifest file that can be used to setup an edge region in
-    a custom kubernetes cluster.
-    """
-
-    client = Client.from_args(args)
-    data, errors = client.get(
-        f"/api/v2/regions/{args.region_name}/deployment-manifest/"
-    )
-    if data:
-        content = b64decode(data["content"]).decode()
-        if args.file_name:
-            try:
-                with open(args.file_name, "x") as file:
-                    file.write(content)
-                    print_success(f"Manifest written to: {args.file_name}")
-            except FileExistsError:
-                print_error(f"The file {args.file_name} already exists.")
-        else:
-            print(content)
-
-    else:
-        print_response(
-            data=data, errors=errors, output_fmt=get_output_format(args),
-        )

--- a/docs/commands/regions.rst
+++ b/docs/commands/regions.rst
@@ -61,23 +61,3 @@ Example
    |---------------+---------------------------------------------------|
    | Edge region   | 2c0d0e22b0e846b2a7acdcbf092e54a3.edge.cratedb.net |
    +---------------+---------------------------------------------------+
-
-
-``regions generate-deployment-manifest``
-========================================
-
-Generate and fetch a deployment manifest for an edge region:
-
-.. argparse::
-   :module: croud.__main__
-   :func: get_parser
-   :prog: croud
-   :path: regions generate-deployment-manifest
-
-Example
-=======
-
-.. code-block:: console
-
-   sh$ croud regions generate-deployment-manifest --region-name region-name
-   The .yaml manifest as output.

--- a/tests/commands/test_regions.py
+++ b/tests/commands/test_regions.py
@@ -124,39 +124,3 @@ def test_regions_create_aborted(mock_request, capsys):
 
     _, err_output = capsys.readouterr()
     assert "Region creation cancelled." in err_output
-
-
-@mock.patch.object(Client, "request", return_value=({}, None))
-def test_get_region_deployment_manifest(mock_request):
-    call_command(
-        "croud",
-        "regions",
-        "generate-deployment-manifest",
-        "--region-name",
-        "region-name",
-        "--yes",
-    )
-    assert_rest(
-        mock_request,
-        RequestMethod.GET,
-        "/api/v2/regions/region-name/deployment-manifest/",
-    )
-
-
-@mock.patch.object(Client, "request", return_value=(None, {}))
-def test_get_region_deployment_manifest_aborted(mock_request, capsys):
-    with mock.patch("builtins.input", side_effect=["Nooooo"]) as mock_input:
-        call_command(
-            "croud",
-            "regions",
-            "generate-deployment-manifest",
-            "--region-name",
-            "region-name",
-        )
-    mock_request.assert_not_called()
-    mock_input.assert_called_once_with(
-        "The generation of a deployment manfiest for an edge region is an experimental feature. Do you really want to use it? [yN] "  # noqa
-    )
-
-    _, err_output = capsys.readouterr()
-    assert "Deployment manifest generation cancelled." in err_output


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Because now, after creating the region, a command is shown to the user that does the whole region installation without Croud.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
