### PR TITLE
Corrected install edge-region script command when creating a new region

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changes for croud
 Unreleased
 ==========
 
+- Added a new type of printer ``raw`` that simply outputs the rows as given.
+
 - Added new subcommand ``regions generate-deployment-manifest`` to fetch a deployment
   manifest for an edge region.
 

--- a/croud/printer.py
+++ b/croud/printer.py
@@ -120,6 +120,17 @@ class JsonFormatPrinter(FormatPrinter):
         return json.dumps(rows, sort_keys=False, indent=2)
 
 
+class RawFormatPrinter(FormatPrinter):
+    def format_rows(self, rows: Union[List[JsonDict], JsonDict]) -> str:
+        if not rows:
+            return ""
+        if type(rows) is dict:
+            return json.dumps(rows)
+        if type(rows) is list:
+            return "\n".join(rows)
+        return rows
+
+
 class TableFormatPrinter(FormatPrinter):
 
     display_all_columns = False
@@ -194,6 +205,7 @@ class YamlFormatPrinter(FormatPrinter):
 
 PRINTERS: Dict[str, Type[FormatPrinter]] = {
     "json": JsonFormatPrinter,
+    "raw": RawFormatPrinter,
     "table": TableFormatPrinter,
     "wide": WideTableFormatPrinter,
     "yaml": YamlFormatPrinter,

--- a/croud/regions/commands.py
+++ b/croud/regions/commands.py
@@ -21,7 +21,7 @@ from argparse import Namespace
 
 from croud.api import Client
 from croud.config import get_output_format
-from croud.printer import print_response, print_success
+from croud.printer import print_response, print_success, print_format
 from croud.util import require_confirmation
 
 
@@ -80,11 +80,16 @@ def regions_create(args: Namespace) -> None:
 
         if not install_token_errors and install_token and "token" in install_token:
             print_success("You have successfully created a region.")
-            print("")
-            print("To install the edge region run the following command:")
-            print("")
-            print(
-                f"  $ bash <( curl –fsSl https://console.crate.cloud/edge/{region['name']}/cratedb-cloud-edge.sh) install {install_token['token']}"  # noqa
+
+            print_format(
+                [
+                    "",
+                    "To install the edge region run the following command:",
+                    "",
+                    f"  $ bash <( wget -qO- {client.base_url}/edge/{region['name']}/cratedb-cloud-edge.sh) {install_token['token']}", # noqa
+                    ""
+                ],
+                "raw",
             )
         else:
             print_response(

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,11 @@ setup(
         "halo==0.0.31",
     ],
     extras_require={
-        "testing": ["tox==3.14.2"],
+        "testing": [
+            "tox==3.14.2",
+            "pytest==6.2.3",
+            "pytest-random-order==1.0.4",
+        ],
         "development": [
             "black==19.10b0",
             "flake8==3.7.9",

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -25,6 +25,7 @@ from croud.printer import (
     WideTableFormatPrinter,
     YamlFormatPrinter,
     print_response,
+    RawFormatPrinter,
 )
 
 
@@ -221,6 +222,24 @@ def test_tabular_format(rows, keys, transforms, expected):
 )
 def test_wide_format(rows, keys, transforms, expected):
     out = WideTableFormatPrinter(keys=keys, transforms=transforms).format_rows(rows)
+    assert out == expected
+
+
+@pytest.mark.parametrize(
+    "rows,expected",
+    (
+        ("test", "test"),
+        (["test"], "test"),
+        (["test", ""], "test\n"),
+        (["test", "this"], "test\nthis"),
+        (None, ""),
+        ([], ""),
+        ({}, ""),
+        ({"test": "true", "me": 1}, '{"test": "true", "me": 1}'),
+    ),
+)
+def test_print_raw(rows, expected):
+    out = RawFormatPrinter().format_rows(rows=rows)
     assert out == expected
 
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

- Corrected install edge-region script command when creating a new region
- Added a new raw format printer
- Added a test for the returned install command
- Changed the command to use `wget` instead of curl


