### PR TITLE
Fixed linter errors. Removed RawFormatPrinter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changes for croud
 Unreleased
 ==========
 
-- Added a new type of printer ``raw`` that simply outputs the rows as given.
+- Added a new ``print_raw`` function to simply print the output of croud.
 
 - Added new subcommand ``regions generate-deployment-manifest`` to fetch a deployment
   manifest for an edge region.

--- a/croud/printer.py
+++ b/croud/printer.py
@@ -75,6 +75,13 @@ def print_response(
         print_success(message)
 
 
+def print_raw(text: Union[List[str], str]):
+    HALO.stop()
+    if type(text) is list:
+        text = "\n".join(text)
+    print(text, file=sys.stderr)
+
+
 def print_error(text: str):
     HALO.stop()
     print(Fore.RED + "==> Error: " + Style.RESET_ALL + text, file=sys.stderr)
@@ -118,17 +125,6 @@ class FormatPrinter(abc.ABC):
 class JsonFormatPrinter(FormatPrinter):
     def format_rows(self, rows: Union[List[JsonDict], JsonDict]) -> str:
         return json.dumps(rows, sort_keys=False, indent=2)
-
-
-class RawFormatPrinter(FormatPrinter):
-    def format_rows(self, rows: Union[List[JsonDict], JsonDict]) -> str:
-        if not rows:
-            return ""
-        if type(rows) is dict:
-            return json.dumps(rows)
-        if type(rows) is list:
-            return "\n".join(rows)
-        return rows
 
 
 class TableFormatPrinter(FormatPrinter):
@@ -205,7 +201,6 @@ class YamlFormatPrinter(FormatPrinter):
 
 PRINTERS: Dict[str, Type[FormatPrinter]] = {
     "json": JsonFormatPrinter,
-    "raw": RawFormatPrinter,
     "table": TableFormatPrinter,
     "wide": WideTableFormatPrinter,
     "yaml": YamlFormatPrinter,

--- a/croud/regions/commands.py
+++ b/croud/regions/commands.py
@@ -21,7 +21,7 @@ from argparse import Namespace
 
 from croud.api import Client
 from croud.config import get_output_format
-from croud.printer import print_response, print_success, print_format
+from croud.printer import print_raw, print_response, print_success
 from croud.util import require_confirmation
 
 
@@ -81,15 +81,14 @@ def regions_create(args: Namespace) -> None:
         if not install_token_errors and install_token and "token" in install_token:
             print_success("You have successfully created a region.")
 
-            print_format(
+            print_raw(
                 [
                     "",
                     "To install the edge region run the following command:",
                     "",
-                    f"  $ bash <( wget -qO- {client.base_url}/edge/{region['name']}/cratedb-cloud-edge.sh) {install_token['token']}", # noqa
-                    ""
+                    f"  $ bash <( wget -qO- {client.base_url}/edge/{region['name']}/cratedb-cloud-edge.sh) {install_token['token']}",  # noqa
+                    "",
                 ],
-                "raw",
             )
         else:
             print_response(

--- a/setup.py
+++ b/setup.py
@@ -53,11 +53,7 @@ setup(
         "halo==0.0.31",
     ],
     extras_require={
-        "testing": [
-            "tox==3.14.2",
-            "pytest==6.2.3",
-            "pytest-random-order==1.0.4",
-        ],
+        "testing": ["tox==3.14.2", "pytest==6.2.3", "pytest-random-order==1.0.4",],
         "development": [
             "black==19.10b0",
             "flake8==3.7.9",

--- a/tests/commands/test_regions.py
+++ b/tests/commands/test_regions.py
@@ -22,7 +22,7 @@ from unittest import mock
 import pytest
 
 from croud.api import Client, RequestMethod
-from croud.printer import RawFormatPrinter
+from croud.printer import print_raw
 from tests.util import assert_rest, call_command
 
 
@@ -95,7 +95,7 @@ def test_regions_create_mandatory_params(mock_request):
     )
 
 
-@mock.patch.object(RawFormatPrinter, "print_rows")
+@mock.patch("croud.regions.commands.print_raw", wraps=print_raw)
 @mock.patch.object(
     Client,
     "request",
@@ -133,12 +133,7 @@ def test_regions_create_install_command(mock_request, mock_raw_printer):
 def test_regions_create_missing_description(mock_request, capsys):
     with pytest.raises(SystemExit):
         call_command(
-            "croud",
-            "regions",
-            "create",
-            "--provider",
-            "EDGE",
-            "--yes",
+            "croud", "regions", "create", "--provider", "EDGE", "--yes",
         )
     mock_request.assert_not_called()
     _, err_output = capsys.readouterr()

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -25,7 +25,6 @@ from croud.printer import (
     WideTableFormatPrinter,
     YamlFormatPrinter,
     print_response,
-    RawFormatPrinter,
 )
 
 
@@ -222,24 +221,6 @@ def test_tabular_format(rows, keys, transforms, expected):
 )
 def test_wide_format(rows, keys, transforms, expected):
     out = WideTableFormatPrinter(keys=keys, transforms=transforms).format_rows(rows)
-    assert out == expected
-
-
-@pytest.mark.parametrize(
-    "rows,expected",
-    (
-        ("test", "test"),
-        (["test"], "test"),
-        (["test", ""], "test\n"),
-        (["test", "this"], "test\nthis"),
-        (None, ""),
-        ([], ""),
-        ({}, ""),
-        ({"test": "true", "me": 1}, '{"test": "true", "me": 1}'),
-    ),
-)
-def test_print_raw(rows, expected):
-    out = RawFormatPrinter().format_rows(rows=rows)
     assert out == expected
 
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

.. as formatprinters only support JsonDict flavors and not simple strings.

