### PR TITLE
Fix Sphinx extensions configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 from crate.theme.rtd.conf.cloud_cli import *  # noqa
 
-extensions += ["sphinx_sitemap", "sphinxarg.ext"]  # type:ignore # noqa:F405
+extensions.append("sphinxarg.ext")  # type:ignore # noqa:F405
 
 html_static_path = ["_static"]
 html_context = {"extra_css_files": ["_static/sphinxarg.css"]}


### PR DESCRIPTION
The `sphinx-docs-theme` specifies a list of default Sphinx extensions in the [src/crate/theme/rtd/conf/__init__.py][1] file.

The `conf.py` file in this Sphinx project also specified a list of Sphinx extensions. However, the way this was done meant that a direct assignment was overwriting the default value of the extensions variable (imported at the start of the file).

As a consequence, the Croud docs have not yet picked up any of the following improvements:

- Intersphinx support
- PlantUML support
- Open Graph support
- [Sphinx copy button][2] support

This change replaces the direct assignment with a list append operation and removes a redundant extension (`sphinx_sitemap`) that is already present in the default list.

I have verified that as a result of this change, the Sphinx copy button correctly appears on code examples as expected (which was previously not the case).

[1]: https://github.com/crate/crate-docs-theme/blob/main/src/crate/theme/rtd/conf/__init__.py#L32
[2]: https://pypi.org/project/sphinx-copybutton/
[3]: https://github.com/crate/crate-docs-theme/issues/258#issuecomment-852080493
