### PR TITLE
Add new command to restart individual nodes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ Unreleased
 
 - Added support for custom backup locations for edge regions.
 
+- Added new subcommand ``clusters restart-node`` that allows superusers to restart
+  a single node in a cluster.
+
 0.27.0 - 2021/06/17
 ===================
 

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -28,6 +28,7 @@ from croud.clusters.commands import (
     clusters_deploy,
     clusters_get,
     clusters_list,
+    clusters_restart_node,
     clusters_scale,
     clusters_upgrade,
 )
@@ -441,6 +442,20 @@ command_tree = {
                     Argument("-y", "--yes", action="store_true", default=False)
                 ],
                 "resolver": clusters_delete,
+            },
+            "restart-node": {
+                "help": "Restart a node in a CrateDB cluster.",
+                "extra_args": [
+                    Argument(
+                        "--cluster-id", type=str, required=True,
+                        help="The CrateDB cluster ID to use.",
+                    ),
+                    Argument(
+                        "--ordinal", type=int, required=True,
+                        help="The ordinal index of the node to restart.",
+                    ),
+                ],
+                "resolver": clusters_restart_node,
             },
         },
     },

--- a/croud/clusters/commands.py
+++ b/croud/clusters/commands.py
@@ -129,6 +129,22 @@ def clusters_delete(args: Namespace) -> None:
     )
 
 
+def clusters_restart_node(args: Namespace) -> None:
+    client = Client.from_args(args)
+    data, errors = client.delete(
+        f"/api/v2/clusters/{args.cluster_id}/nodes/{args.ordinal}"
+    )
+    print_response(
+        data=data,
+        errors=errors,
+        keys=["code", "status"],
+        success_message=(
+            "Node restarted. It may take a few minutes to complete the changes."
+        ),
+        output_fmt=get_output_format(args),
+    )
+
+
 # We want to map the custom hardware specs to slightly nicer params in croud,
 # hence this mapping here
 def _handle_edge_params(body, args):

--- a/docs/commands/clusters.rst
+++ b/docs/commands/clusters.rst
@@ -179,6 +179,36 @@ Example
    is not world readable or writable to prevent unauthorized access to your
    data!
 
+
+``clusters restart-node``
+=========================
+
+.. argparse::
+   :module: croud.__main__
+   :func: get_parser
+   :prog: croud
+   :path: clusters restart-node
+
+Example
+-------
+
+.. code-block:: console
+
+   sh$ croud clusters restart-node \
+       --cluster-id 8d6a7c3c-61d5-11e9-a639-34e12d2331a1 \
+       --ordinal 1
+       --sudo
+   +--------+----------+
+   |   code | status   |
+   |--------+----------|
+   |    200 | Success  |
+   +--------+----------+
+   ==> Success: Node restarted. It may take a few minutes to complete the changes.
+
+.. note::
+
+   This command is only available for superusers.
+
 .. _support: support@crate.io
 .. _string delimitation: https://en.wikipedia.org/wiki/Delimiter
 .. _CrateDB Cloud Console: https://console.cratedb.cloud

--- a/tests/commands/test_clusters.py
+++ b/tests/commands/test_clusters.py
@@ -307,3 +307,23 @@ def test_clusters_delete_aborted(mock_request, capsys):
 
     _, err_output = capsys.readouterr()
     assert "Cluster deletion cancelled." in err_output
+
+
+@mock.patch.object(Client, "request", return_value=({}, None))
+def test_clusters_restart_node(mock_request):
+    ordinal = 1
+    cluster_id = gen_uuid()
+    call_command(
+        "croud",
+        "clusters",
+        "restart-node",
+        "--cluster-id",
+        cluster_id,
+        "--ordinal",
+        str(ordinal),
+    )
+    assert_rest(
+        mock_request,
+        RequestMethod.DELETE,
+        f"/api/v2/clusters/{cluster_id}/nodes/{ordinal}",
+    )


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Added new subcommand ``clusters restart-node`` that allows superusers to restart a single node in a cluster.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
