### PR TITLE
Allow specifying an S3 backup-location-endpoint-url for projects 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased
 - Added new subcommand ``clusters set-deletion-protection`` that allows superusers
   and organization admins to set the deletion protection status of a cluster.
 
+- Added ``--backup-location-endpoint-url`` to allow custom S3 backup locations.
+
 0.28.0 - 2021/07/26
 ===================
 

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -209,6 +209,11 @@ command_tree = {
                              "CrateDB Edge regions only."
                     ),
                     Argument(
+                        "--backup-location-endpoint-url", type=str, required=False,
+                        help="The URL to a S3 compatible endpoint. "
+                             "CrateDB Edge regions only."
+                    ),
+                    Argument(
                         "--backup-location-secret-access-key", type=str, required=False,
                         help="The AWS secret access key for the given s3 bucket. "
                              "CrateDB Edge regions only."

--- a/croud/projects/commands.py
+++ b/croud/projects/commands.py
@@ -109,6 +109,10 @@ def _handle_custom_backups(body, args: Namespace) -> None:
             "access_key_id": args.backup_location_access_key_id,
             "secret_access_key": args.backup_location_secret_access_key,
         }
+    if args.backup_location_endpoint_url:
+        body.setdefault("backup_location", {})["additional_config"] = {
+            "endpoint_url": args.backup_location_endpoint_url,
+        }
 
 
 def _transform_backup_location(field):

--- a/tests/commands/test_projects.py
+++ b/tests/commands/test_projects.py
@@ -68,6 +68,8 @@ def test_projects_create_with_custom_backup(mock_request):
         "123",
         "--backup-location-secret-access-key",
         "321",
+        "--backup-location-endpoint-url",
+        "https://minio.svc.local",
     )
     assert_rest(
         mock_request,
@@ -80,6 +82,7 @@ def test_projects_create_with_custom_backup(mock_request):
                 "location_type": "s3",
                 "location": "some",
                 "credentials": {"access_key_id": "123", "secret_access_key": "321"},
+                "additional_config": {"endpoint_url": "https://minio.svc.local"},
             },
         },
     )


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Adding `--backup-location-endpoint-url` allows specifying a custom S3 endpoint (eg. http://minio.svc.local:9000) for cluster backup. This setting is on `project` level.

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
