### PR TITLE
Add new command to set the deletion protection status of a cluster

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for croud
 Unreleased
 ==========
 
+- Added new subcommand ``clusters set-deletion-protection`` that allows superusers
+  and organization admins to set the deletion protection status of a cluster.
+
 0.28.0 - 2021/07/26
 ===================
 

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -20,6 +20,7 @@
 # software solely pursuant to the terms of the relevant commercial agreement.
 
 import sys
+from distutils.util import strtobool
 
 import colorama
 
@@ -30,6 +31,7 @@ from croud.clusters.commands import (
     clusters_list,
     clusters_restart_node,
     clusters_scale,
+    clusters_set_deletion_protection,
     clusters_upgrade,
 )
 from croud.config import CONFIG
@@ -456,6 +458,20 @@ command_tree = {
                     ),
                 ],
                 "resolver": clusters_restart_node,
+            },
+            "set-deletion-protection": {
+                "help": "Set the deletion protection status of a CrateDB cluster.",
+                "extra_args": [
+                    Argument(
+                        "--cluster-id", type=str, required=True,
+                        help="The CrateDB cluster ID to use.",
+                    ),
+                    Argument(
+                        "--value", type=lambda x: bool(strtobool(str(x))),
+                        required=True, help="The deletion protection status",
+                    ),
+                ],
+                "resolver": clusters_set_deletion_protection,
             },
         },
     },

--- a/croud/clusters/commands.py
+++ b/croud/clusters/commands.py
@@ -145,6 +145,21 @@ def clusters_restart_node(args: Namespace) -> None:
     )
 
 
+def clusters_set_deletion_protection(args: Namespace) -> None:
+    body = {"deletion_protected": args.value}
+    client = Client.from_args(args)
+    data, errors = client.put(
+        f"/api/v2/clusters/{args.cluster_id}/deletion-protection/", body=body
+    )
+    print_response(
+        data=data,
+        errors=errors,
+        keys=["id", "name", "deletion_protected"],
+        success_message=("Cluster deletion protection status successfully updated"),
+        output_fmt=get_output_format(args),
+    )
+
+
 # We want to map the custom hardware specs to slightly nicer params in croud,
 # hence this mapping here
 def _handle_edge_params(body, args):

--- a/docs/commands/clusters.rst
+++ b/docs/commands/clusters.rst
@@ -158,7 +158,7 @@ Example
 
    If you want a more recent backup, there are several options:
 
-   - :ref:`Create an AWS S3 repository <crate-reference:ref-create-repository>`
+   - :ref:`Create an AWS S3 repository <crate-reference:sql-create-repository>`
      with a ``base_path`` of ``/<project_id>/<cluster_id>/<name>``.
      ``<project_id>`` and ``<cluster_id>`` refer to the "dashed" form of the
      corresponding ID (``XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX``). ``<name>``
@@ -208,6 +208,35 @@ Example
 .. note::
 
    This command is only available for superusers.
+
+
+``clusters set-deletion-protection``
+====================================
+
+.. argparse::
+   :module: croud.__main__
+   :func: get_parser
+   :prog: croud
+   :path: clusters set-deletion-protection
+
+Example
+-------
+
+.. code-block:: console
+
+   sh$ croud clusters set-deletion-protection \
+       --cluster-id 8d6a7c3c-61d5-11e9-a639-34e12d2331a1 \
+       --value true
+   +--------------------------------------+------------------------+----------------------+
+   | id                                   | name                   | deletion_protected   |
+   |--------------------------------------+------------------------+----------------------|
+   | 8d6a7c3c-61d5-11e9-a639-34e12d2331a1 | my-first-crate-cluster | TRUE                 |
+   +--------------------------------------+------------------------+----------------------+
+   ==> Success: Cluster deletion protection status successfully updated
+
+.. note::
+
+   This command is only available for superusers and organization admins.
 
 .. _support: support@crate.io
 .. _string delimitation: https://en.wikipedia.org/wiki/Delimiter

--- a/tests/commands/test_clusters.py
+++ b/tests/commands/test_clusters.py
@@ -327,3 +327,24 @@ def test_clusters_restart_node(mock_request):
         RequestMethod.DELETE,
         f"/api/v2/clusters/{cluster_id}/nodes/{ordinal}",
     )
+
+
+@mock.patch.object(Client, "request", return_value=({}, None))
+def test_clusters_set_deletion_protection(mock_request):
+    deletion_protected = True
+    cluster_id = gen_uuid()
+    call_command(
+        "croud",
+        "clusters",
+        "set-deletion-protection",
+        "--cluster-id",
+        cluster_id,
+        "--value",
+        str(deletion_protected).lower(),
+    )
+    assert_rest(
+        mock_request,
+        RequestMethod.PUT,
+        f"/api/v2/clusters/{cluster_id}/deletion-protection/",
+        body={"deletion_protected": deletion_protected},
+    )


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Added new subcommand ``clusters set-deletion-protection`` that allows superusers and organization admins to set the deletion protection status of a cluster.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
