### PR TITLE
Improve 'help' message for disk size

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Unreleased
 
 - Added ``--backup-location-endpoint-url`` to allow custom S3 backup locations.
 
+- Improved help message for disk size argument in ``clusters deploy``
+
 0.28.0 - 2021/07/26
 ===================
 

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -394,7 +394,7 @@ command_tree = {
                     ),
                     Argument(
                         "--disk-size-gb", type=int, required=False,
-                        help="Size of disks to attach (in GB). "
+                        help="Size of disks to attach (in GiB). "
                              "CrateDB Edge regions only.",
                     ),
                     Argument(
@@ -405,7 +405,7 @@ command_tree = {
                     ),
                     Argument(
                         "--memory-size-mb", type=int, required=False,
-                        help="Amount of memory to allocate (in MB). "
+                        help="Amount of memory to allocate (in MiB). "
                              "CrateDB Edge regions only.",
                     )
                 ],


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

The cluster disk size is calculated on a binary basis. The help message is improved to reflect it.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
