### PR TITLE
add set-ip-whitelist option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Unreleased
 
 - Improved help message for disk size argument in ``clusters deploy``
 
+- Added a ``croud clusters set-ip-whitelist`` command to whitelist IP Networks.
+
 0.28.0 - 2021/07/26
 ===================
 

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -32,6 +32,7 @@ from croud.clusters.commands import (
     clusters_restart_node,
     clusters_scale,
     clusters_set_deletion_protection,
+    clusters_set_ip_whitelist,
     clusters_upgrade,
 )
 from croud.config import CONFIG
@@ -477,6 +478,21 @@ command_tree = {
                     ),
                 ],
                 "resolver": clusters_set_deletion_protection,
+            },
+            "set-ip-whitelist": {
+                "help": "Set IP Network Whitelist in CIDR format (comma-separated).",
+                "extra_args": [
+                    Argument(
+                        "--cluster-id", type=str, required=True,
+                        help="The CrateDB cluster ID to use.",
+                    ),
+                    Argument(
+                        "--net", type=str,
+                        required=True,
+                        help="IP Network list in CIDR format (comma-separated).",
+                    ),
+                ],
+                "resolver": clusters_set_ip_whitelist,
             },
         },
     },

--- a/croud/clusters/commands.py
+++ b/croud/clusters/commands.py
@@ -160,6 +160,27 @@ def clusters_set_deletion_protection(args: Namespace) -> None:
     )
 
 
+def clusters_set_ip_whitelist(args: Namespace) -> None:
+    networks = args.net
+    networks = networks.split(",")
+    cidr = []
+
+    for net in networks:
+        cidr.append({"cidr": net})
+
+    client = Client.from_args(args)
+    data, errors = client.put(
+        f"/api/v2/clusters/{args.cluster_id}/ip-restrictions/", body=cidr
+    )  # type: ignore
+    print_response(
+        data=data,
+        errors=errors,
+        keys=["id", "name", "ip_whitelist"],
+        success_message=("IP Network whitelist successfully updated"),
+        output_fmt=get_output_format(args),
+    )
+
+
 # We want to map the custom hardware specs to slightly nicer params in croud,
 # hence this mapping here
 def _handle_edge_params(body, args):

--- a/docs/commands/clusters.rst
+++ b/docs/commands/clusters.rst
@@ -241,3 +241,27 @@ Example
 .. _support: support@crate.io
 .. _string delimitation: https://en.wikipedia.org/wiki/Delimiter
 .. _CrateDB Cloud Console: https://console.cratedb.cloud
+
+
+``clusters set-ip-whitelist``
+====================================
+
+.. argparse::
+   :module: croud.__main__
+   :func: get_parser
+   :prog: croud
+   :path: clusters set-ip-whitelist
+
+Example
+-------
+
+.. code-block:: console
+
+   sh$ croud clusters set-ip-whitelist \
+       --cluster-id 8d6a7c3c-61d5-11e9-a639-34e12d2331a1 \
+       --net "10.1.2.0/24,192.168.1.0/24"
+   +--------------------------------------+---------------+-------------------------------------------------------------------------------------------------+
+   | id                                   | name          | ip_whitelist                                                                                    |
+   |--------------------------------------+---------------+-------------------------------------------------------------------------------------------------|
+   | 8d6a7c3c-61d5-11e9-a639-34e12d2331a1 | romanas-nosub | [{"cidr": "10.1.2.0/24", "description": null}, {"cidr": "192.168.1.0/24", "description": null}] |
+   +--------------------------------------+---------------+-------------------------------------------------------------------------------------------------+

--- a/tests/commands/test_clusters.py
+++ b/tests/commands/test_clusters.py
@@ -348,3 +348,24 @@ def test_clusters_set_deletion_protection(mock_request):
         f"/api/v2/clusters/{cluster_id}/deletion-protection/",
         body={"deletion_protected": deletion_protected},
     )
+
+
+@mock.patch.object(Client, "request", return_value=({}, None))
+def test_clusters_set_ip_whitelist(mock_request):
+    cidr = "8.8.8.8/32,4.4.4.4/32"
+    cluster_id = gen_uuid()
+    call_command(
+        "croud",
+        "clusters",
+        "set-ip-whitelist",
+        "--cluster-id",
+        cluster_id,
+        "--net",
+        cidr,
+    )
+    assert_rest(
+        mock_request,
+        RequestMethod.PUT,
+        f"/api/v2/clusters/{cluster_id}/ip-restrictions/",
+        body=[{"cidr": "8.8.8.8/32"}, {"cidr": "4.4.4.4/32"}],
+    )


### PR DESCRIPTION
## Why this is an improvement
Added ``set-ip-whitelist`` option, sets  ``spec.loadBalancerSourceRanges`` on the crate kubernetes service.

```
croud clusters set-ip-whitelist --cluster-id <> --net "10.1.2.0/24,192.168.1.0/24" 
```

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
