### PR TITLE
Sanitize the default config

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changes for croud
 Unreleased
 ==========
 
+- Sanitized the default config to make it region-agnostic.
+
 0.30.0 - 2021/10/27
 ===================
 

--- a/croud/config/configuration.py
+++ b/croud/config/configuration.py
@@ -30,20 +30,12 @@ from croud.config.types import ConfigurationType, ProfileType
 
 DEFAULT_CONFIGURATION = """\
 default-format: table
-current-profile: aks1.westeurope.azure
+current-profile: cratedb.cloud
 profiles:
-  aks1.eastus2.azure:
+  cratedb.cloud:
     auth-token: NULL
     endpoint: https://console.cratedb.cloud
-    region: aks1.eastus2.azure
-  aks1.westeurope.azure:
-    auth-token: NULL
-    endpoint: https://console.cratedb.cloud
-    region: aks1.westeurope.azure
-  eks1.eu-west-1.aws:
-    auth-token: NULL
-    endpoint: https://console.cratedb.cloud
-    region: eks1.eu-west-1.aws
+    region: _any_
 """
 
 

--- a/docs/commands/config.rst
+++ b/docs/commands/config.rst
@@ -25,20 +25,13 @@ Example
    sh$ croud config show
    ==> Info: Configuration file /home/me/.config/Crate/croud.yaml
    default-format: table
-   current-profile: bregenz.a1
+   current-profile: cratedb.cloud
    profiles:
-     bregenz.a1:
+     cratedb.cloud:
        auth-token: xxxxxxxxxx
-       endpoint: https://bregenz.a1.cratedb.cloud
+       endpoint: https://console.cratedb.cloud
        format: table
-     eastus2.azure:
-       auth-token: xxxxxxxxxx
-       endpoint: https://eastus2.azure.cratedb.cloud
-       format: table
-     westeurope.azure:
-       auth-token: xxxxxxxxxx
-       endpoint: https://westeurope.azure.cratedb.cloud
-       format: table
+       region: _any_
 
 Note, that the values of ``auth-token`` are masked.
 
@@ -61,11 +54,11 @@ Example
 .. code-block:: console
 
    sh$ croud config profiles current
-   +------------+----------------------------------+----------+
-   | name       | endpoint                         | format   |
-   |------------+----------------------------------+----------|
-   | bregenz.a1 | https://bregenz.a1.cratedb.cloud | table    |
-   +------------+----------------------------------+----------+
+   +---------------+----------------------------------+----------+
+   | name          | endpoint                         | format   |
+   |---------------+----------------------------------+----------|
+   | cratedb.cloud | https://console.cratedb.cloud    | table    |
+   +---------------+----------------------------------+----------+
 
 
 ``config profiles use``
@@ -85,5 +78,5 @@ Example
 
 .. code-block:: console
 
-   sh$ croud config profiles use eastus2.azure
-   ==> Info: Switched to profile 'eastus2.azure'.
+   sh$ croud config profiles use some.other
+   ==> Info: Switched to profile 'some.other'.

--- a/tests/commands/test_config.py
+++ b/tests/commands/test_config.py
@@ -71,13 +71,13 @@ def test_config_add_duplicate_profile(config, capsys):
             "config",
             "profiles",
             "add",
-            "aks1.westeurope.azure",
+            "cratedb.cloud",
             "--endpoint",
             "http://localhost:8000",
         )
     assert exc_info.value.code == 1
     _, err = capsys.readouterr()
-    assert "Failed to add profile 'aks1.westeurope.azure'" in err
+    assert "Failed to add profile 'cratedb.cloud'" in err
 
 
 def test_config_current_profile(config, capsys):
@@ -87,11 +87,11 @@ def test_config_current_profile(config, capsys):
 
 
 def test_config_remove_profile(config, capsys):
-    call_command("croud", "config", "profiles", "remove", "aks1.westeurope.azure")
-    assert "aks1.westeurope.azure" not in config.profiles
+    call_command("croud", "config", "profiles", "remove", "cratedb.cloud")
+    assert "cratedb.cloud" not in config.profiles
 
     _, err = capsys.readouterr()
-    assert "Removed profile 'aks1.westeurope.azure'" in err
+    assert "Removed profile 'cratedb.cloud'" in err
 
 
 def test_config_remove_current_profile(config, capsys):
@@ -105,12 +105,21 @@ def test_config_remove_current_profile(config, capsys):
 
 
 def test_config_set_profile(config, capsys):
-    assert config.name != "aks1.westeurope.azure"
-    call_command("croud", "config", "profiles", "use", "aks1.westeurope.azure")
-    assert config.name == "aks1.westeurope.azure"
+    call_command(
+        "croud",
+        "config",
+        "profiles",
+        "add",
+        "new-profile",
+        "--endpoint",
+        "http://localhost:8000",
+    )
+    assert config.name != "new-profile"
+    call_command("croud", "config", "profiles", "use", "new-profile")
+    assert config.name == "new-profile"
 
     _, err = capsys.readouterr()
-    assert "Switched to profile 'aks1.westeurope.azure'" in err
+    assert "Switched to profile 'new-profile'" in err
 
 
 def test_config_set_profile_does_not_exist(config, capsys):

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -84,13 +84,11 @@ def test_default_configuration_instance(tmp_path):
     ):
         config = Configuration("test.yaml")
         assert config._file_path == tmp_path / "test.yaml"
-        assert "aks1.westeurope.azure" in config.profiles
-        assert "aks1.eastus2.azure" in config.profiles
-        assert "eks1.eu-west-1.aws" in config.profiles
-        assert config.name == "aks1.westeurope.azure"
+        assert "cratedb.cloud" in config.profiles
+        assert config.name == "cratedb.cloud"
         assert config.token is None
         assert config.endpoint == "https://console.cratedb.cloud"
-        assert config.region == "aks1.westeurope.azure"
+        assert config.region == "_any_"
         assert config.format == "table"
         assert config.organization is None
 
@@ -127,8 +125,9 @@ default-format: table
 
 
 def test_use_profile(config):
-    config.use_profile("aks1.westeurope.azure")
-    assert config.name == config.config["current-profile"] == "aks1.westeurope.azure"
+    config.add_profile("new", endpoint="http://localhost:8000")
+    config.use_profile("new")
+    assert config.name == config.config["current-profile"] == "new"
 
 
 def test_add_profile(config):
@@ -143,12 +142,12 @@ def test_add_profile(config):
 
 def test_add_profile_duplicate(config):
     with pytest.raises(InvalidProfile):
-        config.add_profile("aks1.eastus2.azure", endpoint="http://localhost:8000")
+        config.add_profile("cratedb.cloud", endpoint="http://localhost:8000")
 
 
 def test_remove_profile(config):
-    config.remove_profile("aks1.eastus2.azure")
-    assert "aks1.eastus2.azure" not in config.config["profiles"]
+    config.remove_profile("cratedb.cloud")
+    assert "cratedb.cloud" not in config.config["profiles"]
 
 
 def test_remove_profile_does_not_exist(config):


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

It makes no sense to have those region-specific endpoints, as they all point to the same thing.


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
