### PR TITLE
Add additional warnings for superuser commands in Croud

### DIFF
--- a/docs/commands/clusters.rst
+++ b/docs/commands/clusters.rst
@@ -10,6 +10,14 @@ The ``clusters`` command lets you manage cluster products.
    non-alphanumeric characters may be interpreted in an unexpected way by your
    shell. Use `string delimitation`_ and escape characters as needed.
 
+.. WARNING::
+
+    Some ``clusters`` commands are only available for CrateDB Cloud sysadmins
+    (superusers). A warning will indicate at the bottom of the documentation
+    for each command when this is the case. They are listed here solely to
+    clarify their function. You can also get information on any command by
+    appending ``--help``.
+
 .. argparse::
    :module: croud.__main__
    :func: get_parser

--- a/docs/commands/index.rst
+++ b/docs/commands/index.rst
@@ -40,6 +40,14 @@ To get help for a specific command, you can append ``--help``:
    permits listing resources regardless of where they're deployed in CrateDB
    Cloud.
 
+.. WARNING::
+
+    Although the Croud CLI is intended to be available to CrateDB Cloud users
+    for cluster operations and other functions, some command arguments (i.e.,
+    in ``clusters`` and ``users``) are only available to CrateDB Cloud sysops
+    (superusers). Whenever this is the case, there is a warning in the
+    corresponding Croud command documentation to indicate this.
+
 .. rubric:: Available commands
 
 .. toctree::


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
- Added additional warnings to make extra sure users are aware some Croud commands are superuser only

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
