### PR TITLE
Add new command to expand disk size of a cluster

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Unreleased
 
 - Added autocompletions for bash/zsh/tcsh
 
+- Added new subcommand ``clusters expand-storage`` that allows superusers and
+  organization admins to expand the disk size of a cluster.
+
 0.32.0 - 2022/02/17
 ===================
 

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -28,6 +28,7 @@ import shtab
 from croud.clusters.commands import (
     clusters_delete,
     clusters_deploy,
+    clusters_expand_storage,
     clusters_get,
     clusters_list,
     clusters_restart_node,
@@ -505,6 +506,20 @@ command_tree = {
                     Argument("-y", "--yes", action="store_true", default=False)
                 ],
                 "resolver": clusters_set_ip_whitelist,
+            },
+            "expand-storage": {
+                "help": "Expand storage of a CrateDB cluster.",
+                "extra_args": [
+                    Argument(
+                        "--cluster-id", type=str, required=True,
+                        help="The CrateDB cluster ID to use.",
+                    ),
+                    Argument(
+                        "--disk-size-gb", type=int, required=True,
+                        help="New size of attached disks (in GiB).",
+                    )
+                ],
+                "resolver": clusters_expand_storage,
             },
         },
     },

--- a/docs/commands/clusters.rst
+++ b/docs/commands/clusters.rst
@@ -298,21 +298,60 @@ Example
        --cluster-id 8d6a7c3c-61d5-11e9-a639-34e12d2331a1 \
        --net "10.1.2.0/24,192.168.1.0/24"
    This will overwrite all existing CIDR restrictions. Continue? [yN] y
-   +--------------------------------------+---------------+----------------+
-   | id                                   | name          | ip_whitelist   |
-   |--------------------------------------+---------------+----------------|
-   | 8d6a7c3c-61d5-11e9-a639-34e12d2331a1 | romanas-nosub | NULL           |
-   +--------------------------------------+---------------+----------------+
+   +--------------------------------------+------------------------+----------------+
+   | id                                   | name                   | ip_whitelist   |
+   |--------------------------------------+------------------------+----------------|
+   | 8d6a7c3c-61d5-11e9-a639-34e12d2331a1 | my-first-crate-cluster | NULL           |
+   +--------------------------------------+------------------------+----------------+
    ==> Info: Updating the IP Network whitelist initiated. It may take a few minutes to complete the changes.
    ==> Info: Status: SENT (Your update request was sent to the region.)
    ==> Info: Status: IN_PROGRESS (Updating IP Network Whitelist.)
    ==> Success: Operation completed.
-   +--------------------------------------+---------------+-------------------------------------------------------------------------------------------------+
-   | id                                   | name          | ip_whitelist                                                                                    |
-   |--------------------------------------+---------------+-------------------------------------------------------------------------------------------------|
-   | 8d6a7c3c-61d5-11e9-a639-34e12d2331a1 | romanas-nosub | [{"cidr": "10.1.2.0/24", "description": null}, {"cidr": "192.168.1.0/24", "description": null}] |
-   +--------------------------------------+---------------+-------------------------------------------------------------------------------------------------+
+   +--------------------------------------+------------------------+-------------------------------------------------------------------------------------------------+
+   | id                                   | name                   | ip_whitelist                                                                                    |
+   |--------------------------------------+------------------------+-------------------------------------------------------------------------------------------------|
+   | 8d6a7c3c-61d5-11e9-a639-34e12d2331a1 | my-first-crate-cluster | [{"cidr": "10.1.2.0/24", "description": null}, {"cidr": "192.168.1.0/24", "description": null}] |
+   +--------------------------------------+------------------------+-------------------------------------------------------------------------------------------------+
 
 .. note::
 
    This command will wait for the operation to finish or fail.
+
+
+``clusters expand-storage``
+===========================
+
+.. argparse::
+   :module: croud.__main__
+   :func: get_parser
+   :prog: croud
+   :path: clusters expand-storage
+
+Example
+-------
+
+.. code-block:: console
+
+   sh$ croud clusters expand-storage \
+       --cluster-id 8d6a7c3c-61d5-11e9-a639-34e12d2331a1 \
+       --disk-size-gb 512
+   +--------------------------------------+------------------------+------------------------------------+
+   | id                                   | name                   | hardware_specs                     |
+   |--------------------------------------+------------------------+------------------------------------|
+   | 8d6a7c3c-61d5-11e9-a639-34e12d2331a1 | my-first-crate-cluster | Disk size: 256.0 GiB               |
+   +--------------------------------------+------------------------+------------------------------------+
+   ==> Info: Cluster storage expansion initiated. It may take a few minutes to complete the changes.
+   ==> Info: Status: REGISTERED (Your storage expansion request was received and is pending processing.)
+   ==> Info: Status: SENT (Your storage expansion request was sent to the region.)
+   ==> Info: Status: IN_PROGRESS (Suspending cluster and waiting for Persistent Volume Claim(s) to be resized.)
+   ==> Info: Status: IN_PROGRESS (Starting cluster. Scaling back up to 3 nodes. Waiting for node(s) to be present.)
+   ==> Success: Operation completed.
+   +--------------------------------------+------------------------+------------------------------------+
+   | id                                   | name                   | hardware_specs                     |
+   |--------------------------------------+------------------------+------------------------------------|
+   | 8d6a7c3c-61d5-11e9-a639-34e12d2331a1 | my-first-crate-cluster | Disk size: 512.0 GiB               |
+   +--------------------------------------+------------------------+------------------------------------+
+
+.. note::
+
+   This command will wait for the operation to finish or fail. It is only available for superusers and organization admins.

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "appdirs==1.4.3",
+        "bitmath==1.3.3.1",
         "certifi",
         "colorama==0.4.3",
         "marshmallow==3.5.1",

--- a/tests/commands/test_clusters.py
+++ b/tests/commands/test_clusters.py
@@ -769,3 +769,87 @@ def test_clusters_reset_ip_whitelist_fails(mock_request, capsys):
 
     _, err_output = capsys.readouterr()
     assert "Some Error" in err_output
+
+
+times_expand_storage_operations_called = 0
+
+
+@pytest.mark.parametrize("status", ["SUCCEEDED", "FAILED", None])
+@mock.patch.object(Client, "request", return_value=({}, None))
+@mock.patch("time.sleep")
+def test_clusters_expand_storage(_mock_sleep, mock_request: mock.Mock, status):
+    disk_size_gb = 256
+    cluster_id = gen_uuid()
+
+    def mock_call(*args, **kwargs):
+        if args[0] == RequestMethod.GET and "/operations/" in args[1]:
+            if status is None:
+                return None, None
+            global times_expand_storage_operations_called
+
+            if times_expand_storage_operations_called == 0:
+                times_expand_storage_operations_called += 1
+                return {"operations": [{"status": "SENT"}]}, None
+            return {"operations": [{"status": status}]}, None
+        return None, None
+
+    mock_request.side_effect = mock_call
+    call_command(
+        "croud",
+        "clusters",
+        "expand-storage",
+        "--cluster-id",
+        cluster_id,
+        "--disk-size-gb",
+        str(disk_size_gb),
+    )
+    print("requests ", mock_request.call_args_list)
+    assert_rest(
+        mock_request,
+        RequestMethod.PUT,
+        f"/api/v2/clusters/{cluster_id}/storage/",
+        body={"disk_size_per_node_bytes": disk_size_gb * 1024 * 1024 * 1024},
+        any_times=True,
+    )
+    assert_rest(
+        mock_request,
+        RequestMethod.GET,
+        f"/api/v2/clusters/{cluster_id}/operations/",
+        params={"type": "EXPAND_STORAGE", "limit": 1},
+        any_times=True,
+    )
+    assert_rest(
+        mock_request,
+        RequestMethod.GET,
+        f"/api/v2/clusters/{cluster_id}/",
+        any_times=True,
+    )
+
+
+@mock.patch.object(Client, "request", return_value=(None, {}))
+def test_cluster_expand_storage_fails(mock_request, capsys):
+    disk_size_gb = 256
+    cluster_id = gen_uuid()
+
+    def mock_call(*args, **kwargs):
+        return None, {"message": "Some Error"}
+
+    mock_request.side_effect = mock_call
+    call_command(
+        "croud",
+        "clusters",
+        "expand-storage",
+        "--cluster-id",
+        cluster_id,
+        "--disk-size-gb",
+        str(disk_size_gb),
+    )
+    assert_rest(
+        mock_request,
+        RequestMethod.PUT,
+        f"/api/v2/clusters/{cluster_id}/storage/",
+        body={"disk_size_per_node_bytes": disk_size_gb * 1024 * 1024 * 1024},
+    )
+
+    _, err_output = capsys.readouterr()
+    assert "Some Error" in err_output


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Added new subcommand `clusters expand-storage` that allows superusers and organization admins to expand the disk size of a cluster.
![image](https://user-images.githubusercontent.com/44063937/159668874-23ff3f1c-645f-48e6-bc44-2d062876c15f.png)

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
