### PR TITLE
Add increment warning to cluster expand-storage command

### DIFF
--- a/docs/commands/clusters.rst
+++ b/docs/commands/clusters.rst
@@ -352,6 +352,9 @@ Example
    | 8d6a7c3c-61d5-11e9-a639-34e12d2331a1 | my-first-crate-cluster | Disk size: 512.0 GiB               |
    +--------------------------------------+------------------------+------------------------------------+
 
-.. note::
+.. NOTE::
 
-   This command will wait for the operation to finish or fail. It is only available for superusers and organization admins.
+    This command will wait for the operation to finish or fail. It is only
+    available for superusers and organization admins. Note that for Azure
+    users, any storage increase exceeding a given increment (32, 64, etc.) will
+    be priced at the level of the next increment.


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
- Adds warning to Croud command `clusters expand-storage` that if you exceed a storage increment, you will pay the price of the next increment

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
