### PR TITLE
Add new command to suspend or resume a cluster

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for croud
 Unreleased
 ==========
 
+- Added new subcommand ``clusters set-suspended-state`` that allows superusers,
+  organization admins and project admins to suspend or resume a cluster.
+
 0.34.0 - 2022/05/10
 ===================
 

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -35,6 +35,7 @@ from croud.clusters.commands import (
     clusters_scale,
     clusters_set_deletion_protection,
     clusters_set_ip_whitelist,
+    clusters_set_suspended,
     clusters_upgrade,
 )
 from croud.config import CONFIG
@@ -525,6 +526,20 @@ command_tree = {
                     )
                 ],
                 "resolver": clusters_expand_storage,
+            },
+            "set-suspended-state": {
+                "help": "Suspend or resume a CrateDB cluster.",
+                "extra_args": [
+                    Argument(
+                        "--cluster-id", type=str, required=True,
+                        help="The CrateDB cluster ID to use.",
+                    ),
+                    Argument(
+                        "--value", type=lambda x: bool(strtobool(str(x))),
+                        required=True, help="The suspended status.",
+                    ),
+                ],
+                "resolver": clusters_set_suspended,
             },
         },
     },

--- a/croud/clusters/commands.py
+++ b/croud/clusters/commands.py
@@ -239,6 +239,40 @@ def clusters_set_deletion_protection(args: Namespace) -> None:
     )
 
 
+def clusters_set_suspended(args: Namespace) -> None:
+    body = {"suspended": args.value}
+    client = Client.from_args(args)
+    data, errors = client.put(f"/api/v2/clusters/{args.cluster_id}/suspend/", body=body)
+    print_response(
+        data=data,
+        errors=errors,
+        keys=["id", "name", "suspended"],
+        output_fmt=get_output_format(args),
+    )
+
+    if errors:
+        return
+    print_info(
+        "Updating the cluster status initiated. "
+        "It may take a few minutes to complete the changes."
+    )
+
+    _wait_for_completed_operation(
+        client=client,
+        cluster_id=args.cluster_id,
+        request_params={"type": "SUSPEND", "limit": 1},
+    )
+
+    # Re-fetch the cluster's info
+    data, errors = client.get(f"/api/v2/clusters/{args.cluster_id}/")
+    print_response(
+        data=data,
+        errors=errors,
+        keys=["id", "name", "suspended"],
+        output_fmt=get_output_format(args),
+    )
+
+
 @require_confirmation("This will overwrite all existing CIDR restrictions. Continue?")
 def clusters_set_ip_whitelist(args: Namespace) -> None:
     networks = args.net

--- a/docs/commands/clusters.rst
+++ b/docs/commands/clusters.rst
@@ -353,3 +353,40 @@ Example
     available for superusers and organization admins. Note that for Azure
     users, any storage increase exceeding a given increment (32, 64, etc.) will
     be priced at the level of the next increment.
+
+
+``clusters set-suspended-state``
+====================================
+
+.. argparse::
+   :module: croud.__main__
+   :func: get_parser
+   :prog: croud
+   :path: clusters set-suspended-state
+
+Example
+-------
+
+.. code-block:: console
+
+   sh$ croud clusters set-suspended-state \
+       --cluster-id 8d6a7c3c-61d5-11e9-a639-34e12d2331a1 \
+       --value true
+   +--------------------------------------+------------------------+----------------+
+   | id                                   | name                   | suspended      |
+   |--------------------------------------+------------------------+----------------|
+   | 8d6a7c3c-61d5-11e9-a639-34e12d2331a1 | my-first-crate-cluster | FALSE          |
+   +--------------------------------------+------------------------+----------------+
+   ==> Info: Updating the cluster status initiated. It may take a few minutes to complete the changes.
+   ==> Info: Status: SENT (Your update request was sent to the region.)
+   ==> Info: Status: IN_PROGRESS (Suspending cluster.)
+   ==> Success: Operation completed.
+   +--------------------------------------+------------------------+----------------+
+   | id                                   | name                   | suspended      |
+   |--------------------------------------+------------------------+----------------|
+   | 8d6a7c3c-61d5-11e9-a639-34e12d2331a1 | my-first-crate-cluster | TRUE           |
+   +--------------------------------------+------------------------+----------------+
+
+.. note::
+
+   This command will wait for the operation to finish or fail.


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Added new subcommand `clusters set-suspended-state` that allows superusers, organization admins and project admins to suspend or resume a cluster.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
