### PR TITLE
Add subscriptions create subcommand

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for croud
 Unreleased
 ==========
 
+- Added new subcommand ``subscriptions create`` that allows superusers to
+  create custom subscriptions.
+
 0.37.0 - 2022/08/19
 ====================
 

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -79,7 +79,11 @@ from croud.projects.users.commands import (
     project_users_remove,
 )
 from croud.regions.commands import regions_create, regions_delete, regions_list
-from croud.subscriptions.commands import subscriptions_get, subscriptions_list
+from croud.subscriptions.commands import (
+    subscriptions_create,
+    subscriptions_get,
+    subscriptions_list,
+)
 from croud.tools.spinner import HALO
 from croud.users.commands import users_list
 from croud.users.roles.commands import roles_list
@@ -798,6 +802,22 @@ command_tree = {
     "subscriptions": {
         "help": "Manage subscriptions.",
         "commands": {
+            "create": {
+                "help": ("Create a subscription in the specified organization. Command "
+                         "is for superusers only."),
+                "extra_args": [
+                    Argument(
+                        "--type", type=str, required=True,
+                        choices=['contract'],
+                        help="The subscription type to use.",
+                    ),
+                    Argument(
+                        "--org-id", type=str, required=True,
+                        help="The organization ID to use.",
+                    ),
+                ],
+                "resolver": subscriptions_create,
+            },
             "get": {
                 "help": (
                     "Get a subscription by its ID."

--- a/croud/subscriptions/commands.py
+++ b/croud/subscriptions/commands.py
@@ -24,6 +24,19 @@ from croud.config import get_output_format
 from croud.printer import print_response
 
 
+def subscriptions_create(args: Namespace) -> None:
+    body = {"type": args.type, "organization_id": args.org_id}
+    client = Client.from_args(args)
+    data, errors = client.post(f"/api/v2/subscriptions/", body=body)
+    print_response(
+        data=data,
+        errors=errors,
+        keys=["id", "name", "state", "provider"],
+        success_message="Subscription created.",
+        output_fmt=get_output_format(args),
+    )
+
+
 def subscriptions_get(args: Namespace) -> None:
     client = Client.from_args(args)
     data, errors = client.get(f"/api/v2/subscriptions/{args.id}/")

--- a/docs/commands/subscriptions.rst
+++ b/docs/commands/subscriptions.rst
@@ -2,6 +2,32 @@
 ``subscriptions``
 =================
 
+``subscriptions create``
+========================
+
+.. argparse::
+   :module: croud.__main__
+   :func: get_parser
+   :prog: croud
+   :path: subscriptions create
+
+Example
+-------
+
+.. code-block:: console
+
+   sh$ croud subscriptions create --type contract --org-id a0df2925-cc73-4365-8a10-7ef847632b81 --sudo
+   +--------------------------------------+-------------------+---------+------------+
+   | id                                   | name              | state   | provider   |
+   |--------------------------------------+-------------------+---------+------------|
+   | 4841eb8a-257d-460d-9dcf-c6a7f0dcc09d | contract-YeBfJLWA | active  | cloud      |
+   +--------------------------------------+-------------------+---------+------------+
+   ==> Success: Subscription created.
+
+.. note::
+
+   This command is only available for superusers.
+
 ``subscriptions list``
 ======================
 

--- a/tests/commands/test_subscriptions.py
+++ b/tests/commands/test_subscriptions.py
@@ -46,3 +46,22 @@ def test_subscriptions_get(mock_request):
     id = str(uuid.uuid4())
     call_command("croud", "subscriptions", "get", id)
     assert_rest(mock_request, RequestMethod.GET, f"/api/v2/subscriptions/{id}/")
+
+
+@mock.patch.object(Client, "request", return_value=({}, None))
+def test_subscriptions_create(mock_request):
+    call_command(
+        "croud",
+        "subscriptions",
+        "create",
+        "--type",
+        "contract",
+        "--org-id",
+        "organization-id",
+    )
+    assert_rest(
+        mock_request,
+        RequestMethod.POST,
+        "/api/v2/subscriptions/",
+        body={"type": "contract", "organization_id": "organization-id"},
+    )


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Added new subcommand `subscriptions create` that allows superusers to create custom subscriptions. E.g. a subscription of type `contract`

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
