### PR TITLE
Prepare release 0.38.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for croud
 Unreleased
 ==========
 
+0.38.0 - 2022/10/24
+===================
+
 - Added new subcommand ``subscriptions create`` that allows superusers to
   create custom subscriptions.
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@
 from pkg_resources.extern.packaging.version import Version
 from setuptools import find_packages, setup
 
-__version__ = Version("0.37.0")
+__version__ = Version("0.38.0")
 
 try:
     with open("README.rst", "r", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
