### PR TITLE
Added new command to cancel Stripe subscriptions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,12 @@ Changes for croud
 Unreleased
 ==========
 
+- Include the organization id when listing subscriptions.
+
+- Fixed the ``LOG_API`` param to correctly use booleans in Python :/
+
+- Added a new command allowing cancelling Stripe subscriptions.
+
 0.39.0 - 2022/11/16
 ===================
 

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -80,6 +80,7 @@ from croud.projects.users.commands import (
 )
 from croud.regions.commands import regions_create, regions_delete, regions_list
 from croud.subscriptions.commands import (
+    subscription_delete,
     subscriptions_create,
     subscriptions_get,
     subscriptions_list,
@@ -827,6 +828,19 @@ command_tree = {
                     ),
                 ],
                 "resolver": subscriptions_get,
+            },
+            "delete": {
+                "help": "For Stripe only. Cancels the specified subscription. "
+                        "CAVEAT EMPTOR! "
+                        "This will delete any clusters running in this subscription.",
+                "extra_args": [
+                    Argument(
+                        "--subscription-id", type=str, required=True,
+                        help="The ID of the subscription.",
+                    ),
+                    Argument("-y", "--yes", action="store_true", default=False),
+                ],
+                "resolver": subscription_delete,
             },
             "list": {
                 "help": "List all subscriptions the current user has access to.",

--- a/croud/api.py
+++ b/croud/api.py
@@ -46,7 +46,7 @@ def noop(*args, **kwargs):
 
 
 def debug(method, endpoint, params, body):
-    if bool(os.getenv("LOG_API", "false")):
+    if os.getenv("LOG_API", "false").lower() == "true":
         msg = f"{method.upper()} {endpoint}"
         if params:
             msg += f" QS={params}"

--- a/croud/subscriptions/commands.py
+++ b/croud/subscriptions/commands.py
@@ -22,6 +22,7 @@ from argparse import Namespace
 from croud.api import Client
 from croud.config import get_output_format
 from croud.printer import print_response
+from croud.util import require_confirmation
 
 
 def subscriptions_create(args: Namespace) -> None:
@@ -57,6 +58,25 @@ def subscriptions_list(args: Namespace) -> None:
     print_response(
         data=data,
         errors=errors,
-        keys=["id", "name", "state", "provider"],
+        keys=["id", "name", "organization_id", "state", "provider"],
+        output_fmt=get_output_format(args),
+    )
+
+
+@require_confirmation(
+    "Are you sure you want to cancel this subscription? "
+    "This will delete any clusters running in this subscription.",
+    cancel_msg="Deletion cancelled.",
+)
+def subscription_delete(args: Namespace) -> None:
+    client = Client.from_args(args)
+    data, errors = client.delete(
+        f"/api/v2/stripe/subscriptions/{args.subscription_id}/"
+    )
+    print_response(
+        data=data,
+        errors=errors,
+        success_message="Subscription cancelled.",
+        keys=["id", "name", "organization_id", "state", "provider"],
         output_fmt=get_output_format(args),
     )

--- a/docs/commands/subscriptions.rst
+++ b/docs/commands/subscriptions.rst
@@ -51,3 +51,24 @@ Example
    | 56149db0-ea40-4616-88d1-885f6a491989 | my-azure-subscription                 | active | azure    |
    | b01b93e0-fd18-4896-ba88-288efe759bf0 | x43z8qxk9nh7l7mq7nxd3907z-zWG1GEiPuM4 | active | aws      |
    +--------------------------------------+---------------------------------------+--------+----------+
+
+``subscriptions delete``
+========================
+
+Cancel a Stripe subscription in a user's organisation. Please note that this will delete
+any clusters running in this subscription, so use carefully:
+
+.. argparse::
+   :module: croud.__main__
+   :func: get_parser
+   :prog: croud
+   :path: subscriptions delete
+
+Example
+-------
+
+.. code-block:: console
+
+   sh$ croud subscriptions delete --subscription-id 035f1161-402e-44b4-9073-0749586091e0
+   Are you sure you want to cancel this subscription? This will delete any clusters running in this subscription. [yN] y
+   ==> Success: Subscription cancelled.


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Also updated subscriptions list to show the org_id, as it's useful if the user has multiple orgs.

And fixed the LOG_API param to correctly use Python booleans.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
