### PR TITLE
Unified some commands in the clusters namespace

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence,
 # The users listed below are global owners and will be
 # requested for review when someone opens a pull request.
-*       @plaharanne @tomach @WalBeh @Taliik
+*       @plaharanne @tomach @WalBeh @Taliik @juanpardo

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@ Unreleased
 
 - Added support for Dependabot.
 
+- BREAKING CHANGE! Changed ``clusters change-product`` to ``clusters set-product`` and
+  ``clusters change-backup-schedule`` to ``clusters set-backup-schedule``. This unifies
+  all the clusters commands to use the same wording.
+
 0.40.0 - 2022/11/18
 ===================
 

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -26,8 +26,6 @@ import colorama
 import shtab
 
 from croud.clusters.commands import (
-    clusters_change_backup_schedule,
-    clusters_change_product,
     clusters_delete,
     clusters_deploy,
     clusters_expand_storage,
@@ -35,8 +33,10 @@ from croud.clusters.commands import (
     clusters_list,
     clusters_restart_node,
     clusters_scale,
+    clusters_set_backup_schedule,
     clusters_set_deletion_protection,
     clusters_set_ip_whitelist,
+    clusters_set_product,
     clusters_set_suspended,
     clusters_upgrade,
 )
@@ -546,8 +546,8 @@ command_tree = {
                 ],
                 "resolver": clusters_set_suspended,
             },
-            "change-product": {
-                "help": "Change the cluster product.",
+            "set-product": {
+                "help": "Change the cluster's product.",
                 "extra_args": [
                     Argument(
                         "--cluster-id", type=str, required=True,
@@ -558,10 +558,10 @@ command_tree = {
                         help="The new product name to use."
                     )
                 ],
-                "resolver": clusters_change_product,
+                "resolver": clusters_set_product,
             },
-            "change-backup-schedule": {
-                "help": "Change the cluster backup schedule.",
+            "set-backup-schedule": {
+                "help": "Change the cluster's backup schedule.",
                 "extra_args": [
                     Argument(
                         "--cluster-id", type=str, required=True,
@@ -574,7 +574,7 @@ command_tree = {
                              "least one value and can have up to 24, comma-separated."
                     )
                 ],
-                "resolver": clusters_change_backup_schedule,
+                "resolver": clusters_set_backup_schedule,
             },
         },
     },

--- a/croud/clusters/commands.py
+++ b/croud/clusters/commands.py
@@ -364,7 +364,7 @@ def clusters_expand_storage(args: Namespace) -> None:
     )
 
 
-def clusters_change_product(args: Namespace) -> None:
+def clusters_set_product(args: Namespace) -> None:
     body = {
         "product_name": args.product_name,
     }
@@ -403,7 +403,7 @@ def clusters_change_product(args: Namespace) -> None:
     )
 
 
-def clusters_change_backup_schedule(args: Namespace) -> None:
+def clusters_set_backup_schedule(args: Namespace) -> None:
     body = {
         "backup_hours": args.backup_hours,
     }

--- a/docs/commands/clusters.rst
+++ b/docs/commands/clusters.rst
@@ -404,21 +404,21 @@ Example
    This command will wait for the operation to finish or fail.
 
 
-``clusters change-product``
-===========================
+``clusters set-product``
+========================
 
 .. argparse::
    :module: croud.__main__
    :func: get_parser
    :prog: croud
-   :path: clusters change-product
+   :path: clusters set-product
 
 Example
 -------
 
 .. code-block:: console
 
-   sh$ croud clusters change-product \
+   sh$ croud clusters set-product \
        --cluster-id 8d6a7c3c-61d5-11e9-a639-34e12d2331a1 \
        --product-name cr2
    +--------------------------------------+------------------------+----------------+
@@ -437,6 +437,41 @@ Example
    |--------------------------------------+------------------------+----------------|
    | 8d6a7c3c-61d5-11e9-a639-34e12d2331a1 | my-first-crate-cluster | cr2            |
    +--------------------------------------+------------------------+----------------+
+
+.. NOTE::
+
+    This command will wait for the operation to finish or fail. It is only available
+    to organization and project admins.
+
+
+``clusters set-backup-schedule``
+================================
+
+.. argparse::
+   :module: croud.__main__
+   :func: get_parser
+   :prog: croud
+   :path: clusters set-backup-schedule
+
+Example
+-------
+
+.. code-block:: console
+
+   sh$ ❯ croud clusters set-backup-schedule --cluster-id 705a7012-3f89-441d-a10e-b3749d05e993 --backup-hours 2,4,6
+   +--------------------------------------+------------------------+-------------------+
+   | id                                   | name                   | backup_schedule   |
+   |--------------------------------------+------------------------+-------------------|
+   | 705a7012-3f89-441d-a10e-b3749d05e993 | my-cratedb-cluster     | 55 6 * * *        |
+   +--------------------------------------+------------------------+-------------------+
+   ==> Info: Changing the cluster backup schedule. It may take a few minutes to complete the changes.
+   ==> Info: Status: REGISTERED (Your update backup schedule request was received and is pending processing.)
+   ==> Success: Operation completed.
+   +--------------------------------------+------------------------+-------------------+
+   | id                                   | name                   | backup_schedule   |
+   |--------------------------------------+------------------------+-------------------|
+   | 705a7012-3f89-441d-a10e-b3749d05e993 | my-cratedb-cluster     | 55 2,4,6 * * *    |
+   +--------------------------------------+------------------------+-------------------+
 
 .. NOTE::
 

--- a/tests/commands/test_clusters.py
+++ b/tests/commands/test_clusters.py
@@ -931,7 +931,7 @@ def test_clusters_change_product(_mock_sleep, mock_request: mock.Mock, status):
     call_command(
         "croud",
         "clusters",
-        "change-product",
+        "set-product",
         "--cluster-id",
         cluster_id,
         "--product-name",
@@ -972,7 +972,7 @@ def test_clusters_change_product_fails(mock_request, capsys):
     call_command(
         "croud",
         "clusters",
-        "change-product",
+        "set-product",
         "--cluster-id",
         cluster_id,
         "--product-name",
@@ -995,7 +995,10 @@ times_change_backup_schedule_called = 0
 @pytest.mark.parametrize("status", ["SUCCEEDED"])
 @pytest.mark.parametrize("backup_hours", ["12", "4,5,6", "4-8"])
 @mock.patch.object(Client, "request", return_value=({}, None))
-def test_clusters_change_backup_schedule(mock_request: mock.Mock, backup_hours, status):
+@mock.patch("time.sleep")
+def test_clusters_change_backup_schedule(
+    _mock_time, mock_request: mock.Mock, backup_hours, status
+):
     cluster_id = gen_uuid()
 
     def mock_call(*args, **kwargs):
@@ -1012,7 +1015,7 @@ def test_clusters_change_backup_schedule(mock_request: mock.Mock, backup_hours, 
     call_command(
         "croud",
         "clusters",
-        "change-backup-schedule",
+        "set-backup-schedule",
         "--cluster-id",
         cluster_id,
         "--backup-hours",
@@ -1052,7 +1055,7 @@ def test_clusters_change_backup_schedule_fails(mock_request: mock.Mock, capsys):
     call_command(
         "croud",
         "clusters",
-        "change-backup-schedule",
+        "set-backup-schedule",
         "--cluster-id",
         cluster_id,
         "--backup-hours",


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

`clusters change-product` to `clusters set-product` and `clusters change-backup-schedule` to `clusters set-backup-schedule`. Note that technically this is a breaking change, so we should probably bump `croud` to version 1.0.0 upon the next release.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
