### PR TITLE
Prepare release 1.2.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changes for croud
 Unreleased
 ==========
 
+1.2.0 - 2022/12/21
+==================
+
+- Added support for listing and restoring snapshots, including cloning clusters.
+
 1.1.0 - 2022/12/12
 ==================
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@
 from pkg_resources.extern.packaging.version import Version
 from setuptools import find_packages, setup
 
-__version__ = Version("1.1.0")
+__version__ = Version("1.2.0")
 
 try:
     with open("README.rst", "r", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
- Added support for listing and restoring snapshots, including cloning clusters.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
