### PR TITLE
Added an ability to specify the `--days-ago` argument to `snapshots list`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   documentation:
     name: Build docs on ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     branches:
       - master
+
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   lint:
     name: Code style checks and static analysis with Python ${{ matrix.python-version }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@ Unreleased
 - Unfix the version of ``tabulate`` to maintain compatibility with crash. Currently
   not possible to install both crash and croud in the same python environment.
 
+- Added an ability to specify the ``--days-ago`` argument to ``snapshots list``.
+  This fixes an issue where no snapshots could be listed if the cluster was suspended
+  for longer than 2 days.
+
 1.2.0 - 2022/12/21
 ==================
 

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -594,6 +594,10 @@ command_tree = {
                                 "--cluster-id", type=str, required=True,
                                 help="The CrateDB cluster ID to use.",
                             ),
+                            Argument(
+                                "--days-ago", type=int, required=False, default=2,
+                                help="Number of days to look back.",
+                            ),
                         ],
                         "resolver": clusters_snapshots_list,
                     },

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,6 @@ include_trailing_comma = true
 known_first_party = croud,tests
 line_length = 88
 multi_line_output = 3
-not_skip = __init__.py
 
 [tool:pytest]
 addopts = --doctest-modules --doctest-glob='**/*.rst' --ignore=docs --random-order

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,10 @@ setup(
         "shtab==1.5.8",
     ],
     extras_require={
-        "testing": ["tox==3.14.2"],
+        "testing": [
+            "tox==3.14.2",
+            "pytest-freezegun==0.4.2",
+        ],
         "development": [
             "black==22.12.0",
             "flake8==3.8.4",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
 pytest==7.2.0
 pytest-random-order==1.1.0
+pytest-freezegun==0.4.2

--- a/tests/commands/test_clusters.py
+++ b/tests/commands/test_clusters.py
@@ -1159,7 +1159,7 @@ def test_cluster_suspended_fails(mock_request, capsys):
     assert "Some Error" in err_output
 
 
-@pytest.mark.freeze_time("2023-01-02 00:00:00")
+@pytest.mark.freeze_time("2023-01-02 00:00:00.00+00:00")
 @mock.patch.object(
     Client,
     "request",
@@ -1205,7 +1205,7 @@ def test_cluster_snapshots_list(mock_request, capsys):
     assert "20230101083912" in stdout
 
 
-@pytest.mark.freeze_time("2023-01-02 00:00:00")
+@pytest.mark.freeze_time("2023-01-02 00:00:00.00+00:00")
 @pytest.mark.parametrize("days", [None, 1, 14, 365])
 @mock.patch.object(Client, "request", return_value=([], {}))
 def test_cluster_snapshots_list_no_backups(mock_request, days, capsys):


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This fixes an issue where no snapshots could be listed if the cluster was suspended for longer than 2 days.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
