### PR TITLE
Add support for cancelling contract subscriptions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Unreleased
 
 - Added support for data import jobs on clusters.
 
+- Added support for cancelling contract subscriptions.
+
 1.2.1 - 2023/01/05
 ==================
 

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -1012,7 +1012,8 @@ command_tree = {
                 "resolver": subscriptions_get,
             },
             "delete": {
-                "help": "For Stripe only. Cancels the specified subscription. "
+                "help": "For Stripe or contract subscriptions only. Cancels the "
+                        "specified subscription. "
                         "CAVEAT EMPTOR! "
                         "This will delete any clusters running in this subscription.",
                 "extra_args": [

--- a/croud/subscriptions/commands.py
+++ b/croud/subscriptions/commands.py
@@ -70,9 +70,7 @@ def subscriptions_list(args: Namespace) -> None:
 )
 def subscription_delete(args: Namespace) -> None:
     client = Client.from_args(args)
-    data, errors = client.delete(
-        f"/api/v2/stripe/subscriptions/{args.subscription_id}/"
-    )
+    data, errors = client.delete(f"/api/v2/subscriptions/{args.subscription_id}/")
     print_response(
         data=data,
         errors=errors,

--- a/docs/commands/subscriptions.rst
+++ b/docs/commands/subscriptions.rst
@@ -55,7 +55,7 @@ Example
 ``subscriptions delete``
 ========================
 
-Cancel a Stripe subscription in a user's organisation. Please note that this will delete
+Cancel a Stripe or contract subscription in a user's organisation. Please note that this will delete
 any clusters running in this subscription, so use carefully:
 
 .. argparse::

--- a/tests/commands/test_subscriptions.py
+++ b/tests/commands/test_subscriptions.py
@@ -85,9 +85,7 @@ def test_subscriptions_delete(mock_request, capsys):
     sub_id = gen_uuid()
     with mock.patch("builtins.input", side_effect=["yes"]) as mock_input:
         call_command("croud", "subscriptions", "delete", "--subscription-id", sub_id)
-    assert_rest(
-        mock_request, RequestMethod.DELETE, f"/api/v2/stripe/subscriptions/{sub_id}/"
-    )
+    assert_rest(mock_request, RequestMethod.DELETE, f"/api/v2/subscriptions/{sub_id}/")
     mock_input.assert_called_once_with(
         "Are you sure you want to cancel this subscription? "
         "This will delete any clusters running in this subscription. [yN] "


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
depends on https://github.com/crate/cloud-api/pull/2436
Change the API url for cancelling subscriptions from `/api/v2/stripe/subscriptions/<subscription_id>/` to `/api/v2/subscriptions/<subscription_id>/` which also allows cancelling contract subscriptions.

https://github.com/crate/cloud/issues/1131

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
