### PR TITLE
Added the suspended state to croud cluster responses.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ Unreleased
 
 - Added support for cancelling contract subscriptions.
 
+- Added the ``suspended`` state to croud cluster responses.
+
 1.2.1 - 2023/01/05
 ==================
 

--- a/croud/clusters/commands.py
+++ b/croud/clusters/commands.py
@@ -63,6 +63,7 @@ def clusters_list(args: Namespace) -> None:
             "crate_version",
             "project_id",
             "username",
+            "suspended",
             "fqdn",
             "channel",
         ],


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This is useful to know when listing clusters.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
