### PR TITLE
Slightly spruced up import job handling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Changes for croud
 Unreleased
 ==========
 
+- Changed import jobs status to show the error message if an import fails.
+
+- Added the URL to the import jobs list output.
+
 1.3.0 - 2023/03/14
 ==================
 

--- a/croud/clusters/commands.py
+++ b/croud/clusters/commands.py
@@ -238,8 +238,12 @@ def import_jobs_list(args: Namespace) -> None:
     print_response(
         data=data,
         errors=errors,
-        keys=["id", "cluster_id", "status", "type", "destination"],
+        keys=["id", "cluster_id", "status", "type", "url", "destination"],
         output_fmt=get_output_format(args),
+        transforms={
+            "url": lambda field: field.get("url"),
+            "destination": lambda field: field.get("table"),
+        },
     )
 
 
@@ -685,10 +689,13 @@ def _wait_for_completed_operation(
             print_success("Operation completed.")
             break
         if status == "FAILED":
-            print_error(
-                "Your cluster operation has failed. "
-                "Our operations team is investigating the issue."
-            )
+            if msg:
+                print_error(msg)
+            else:
+                print_error(
+                    "Your cluster operation has failed. "
+                    "Our operations team is investigating the issue."
+                )
             break
 
         with HALO:

--- a/tests/commands/test_clusters.py
+++ b/tests/commands/test_clusters.py
@@ -1427,3 +1427,41 @@ def test_import_job_create(mock_request):
         body=body,
         any_times=True,
     )
+
+
+@mock.patch.object(
+    Client,
+    "request",
+    return_value=(
+        [
+            {
+                "cluster_id": "123",
+                "compression": "gzip",
+                "dc": {
+                    "created": "2023-03-14T10:12:29.763000+00:00",
+                    "modified": "2023-03-14T10:12:29.763000+00:00",
+                },
+                "destination": {"create_table": True, "table": "croud-csv-import-two"},
+                "format": "csv",
+                "id": "a95e5a20-61f7-415f-b128-1e21ddf17513",
+                "progress": {
+                    "bytes": 0,
+                    "message": "Failed",
+                    "records": 0,
+                },
+                "status": "FAILED",
+                "type": "url",
+                "url": {"url": "https://some"},
+            }
+        ],
+        None,
+    ),
+)
+def test_import_job_list(mock_request):
+    call_command("croud", "clusters", "import-jobs", "list", "--cluster-id", "123")
+    assert_rest(
+        mock_request,
+        RequestMethod.GET,
+        "/api/v2/clusters/123/import-jobs/",
+        params=None,
+    )


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

- Changed import jobs status to show the error message if an import fails.
- Added the URL to the import jobs list output.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
