### PR TITLE
Add support for cluster export jobs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,12 @@ Unreleased
   This is done by specifying a ``--org-id`` and ``--region``, at which point
   the project will be created on-the-fly.
 
+- Added new resource ``clusters export-jobs`` and subcommands that allow
+  organization admins to manage export jobs.
+
+- Added new subcommand ``get`` for the resource ``organizations files`` that
+  returns a single file by its ID.
+
 1.4.0 - 2023/06/22
 ==================
 

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -47,6 +47,9 @@ from croud.clusters.commands import (
     clusters_snapshots_list,
     clusters_snapshots_restore,
     clusters_upgrade,
+    export_jobs_create,
+    export_jobs_delete,
+    export_jobs_list,
     import_jobs_create_from_file,
     import_jobs_create_from_url,
     import_jobs_delete,
@@ -67,6 +70,7 @@ from croud.organizations.auditlogs.commands import auditlogs_list
 from croud.organizations.commands import (
     org_files_create,
     org_files_delete,
+    org_files_get,
     org_files_list,
     organizations_create,
     organizations_delete,
@@ -762,6 +766,78 @@ command_tree = {
                     },
                 },
             },
+            "export-jobs": {
+                "help": "Manage data export jobs.",
+                "commands": {
+                    "delete": {
+                        "help": "Cancels an already running data export job that has "
+                                "not finished yet. "
+                                "If the job has already finished it deletes it from "
+                                "the job history.",
+                        "extra_args": [
+                            Argument(
+                                "--cluster-id", type=str, required=True,
+                                help="The cluster the job belongs to."
+                            ),
+                            Argument(
+                                "--export-job-id", type=str,
+                                required=True,
+                                help="The ID of the export job."
+                            ),
+                        ],
+                        "resolver": export_jobs_delete,
+                    },
+                    "list": {
+                        "help": "Lists data export jobs that belong to a specific "
+                                "cluster.",
+                        "extra_args": [
+                            Argument(
+                                "--cluster-id", type=str, required=True,
+                                help="The cluster the export jobs belong to."
+                            ),
+                        ],
+                        "resolver": export_jobs_list,
+                    },
+                    "create": {
+                        "help": "Create a data export job for the specified cluster.",
+                        "extra_args": [
+                            Argument(
+                                "--cluster-id", type=str, required=True,
+                                help="The cluster the data will be exported from."
+                            ),
+                            Argument(
+                                "--table",
+                                type=str,
+                                required=True,
+                                help="The table the data will be exported from.",
+                            ),
+                            Argument(
+                                "--file-format",
+                                type=str,
+                                required=True,
+                                choices=["csv", "json", "parquet"],
+                                help="The format of the data in the file.",
+                            ),
+                            Argument(
+                                "--compression",
+                                type=str,
+                                required=False,
+                                choices=["gzip"],
+                                help="The compression method of the exported file.",
+                            ),
+                            Argument(
+                                "--save-as",
+                                type=str,
+                                required=False,
+                                help="The file on your local filesystem the data will "
+                                     "be exported to. If not specified, you will "
+                                     "receive the URL to download the file.",
+                            ),
+                        ],
+                        "resolver": export_jobs_create,
+                    },
+                },
+            },
         },
     },
     "products": {
@@ -924,6 +1000,22 @@ command_tree = {
             "files": {
                 "help": "Manage organization's files.",
                 "commands": {
+                    "get": {
+                        "help": (
+                            "Get a file by its ID."
+                        ),
+                        "extra_args": [
+                            Argument(
+                                "--org-id", type=str, required=True,
+                                help="The organization ID to use.",
+                            ),
+                            Argument(
+                                "--file-id", type=str, required=True,
+                                help="The ID of the file.",
+                            ),
+                        ],
+                        "resolver": org_files_get,
+                    },
                     "list": {
                         "help": "List all files uploaded to this organization.",
                         "extra_args": [

--- a/croud/organizations/commands.py
+++ b/croud/organizations/commands.py
@@ -20,6 +20,7 @@ import os
 from argparse import Namespace
 from typing import Any, Tuple
 
+import bitmath
 import requests
 from tqdm import tqdm
 from tqdm.utils import CallbackIOWrapper
@@ -193,3 +194,25 @@ def org_files_delete(args: Namespace) -> None:
         success_message="File upload deleted.",
         output_fmt=get_output_format(args),
     )
+
+
+def org_files_get(args: Namespace) -> None:
+    client = Client.from_args(args)
+    data, errors = client.get(
+        f"/api/v2/organizations/{args.org_id}/files/{args.file_id}/"
+    )
+    print_response(
+        data=data,
+        errors=errors,
+        keys=["id", "name", "status", "file_size", "download_url"],
+        output_fmt=get_output_format(args),
+        transforms={
+            "file_size": _transform_file_size,
+        },
+    )
+
+
+def _transform_file_size(size_bytes):
+    if not size_bytes:
+        return None
+    return bitmath.Byte(size_bytes).best_prefix().format("{value:.2f} {unit}")

--- a/docs/commands/clusters.rst
+++ b/docs/commands/clusters.rst
@@ -585,4 +585,95 @@ Example
     This command will wait for the operation to finish or fail. It is only available
     to organization and project admins.
 
+
+``clusters export-jobs``
+========================
+
+.. argparse::
+   :module: croud.__main__
+   :func: get_parser
+   :prog: croud
+   :path: clusters export-jobs
+   :nosubcommands:
+
+
+``clusters export-jobs create``
+===============================
+
+.. argparse::
+   :module: croud.__main__
+   :func: get_parser
+   :prog: croud
+   :path: clusters export-jobs create
+
+Example
+-------
+
+.. code-block:: console
+
+   sh$ ❯ croud clusters export-jobs create --cluster-id f6c39580-5719-431d-a508-0cee4f9e8209 \
+         --table nyc_taxi --file-format csv
+   +--------------------------------------+--------------------------------------+------------+
+   | id                                   | cluster_id                           | status     |
+   |--------------------------------------+--------------------------------------+------------|
+   | 85dc0024-b049-4b9d-b100-4bf850881692 | f6c39580-5719-431d-a508-0cee4f9e8209 | REGISTERED |
+   +--------------------------------------+--------------------------------------+------------+
+   ==> Info: Status: SENT (Your creation request was sent to the region.)
+   ==> Info: Status: IN_PROGRESS (Export in progress)
+   ==> Info: Exporting... 2.00 K records and 19.53 KiB exported so far.
+   ==> Info: Exporting... 4.00 K records and 39.06 KiB exported so far.
+   ==> Info: Done exporting 6.00 K records and 58.59 KiB.
+   ==> Success: Download URL: https://cratedb-file-uploads.s3.amazonaws.com/some/download
+   ==> Success: Operation completed.
+
+
+.. NOTE::
+
+    This command will wait for the operation to finish or fail. It is only available
+    to organization admins.
+
+
+``clusters export-jobs list``
+=============================
+
+.. argparse::
+   :module: croud.__main__
+   :func: get_parser
+   :prog: croud
+   :path: clusters export-jobs list
+
+Example
+-------
+
+.. code-block:: console
+
+   sh$ ❯ croud clusters export-jobs list \
+         --cluster-id f6c39580-5719-431d-a508-0cee4f9e8209
+   +--------------------------------------+--------------------------------------+-----------+---------------------+-----------------------------------------------+
+   | id                                   | cluster_id                           | status    | source              | destination                                   |
+   |--------------------------------------+--------------------------------------+-----------+---------------------+-----------------------------------------------|
+   | b311ba9d-9cb4-404a-b58d-c442ae251dbf | f6c39580-5719-431d-a508-0cee4f9e8209 | SUCCEEDED | nyc_taxi            | Format: csv                                   |
+   |                                      |                                      |           |                     | File ID: 327ad0e6-607f-4f99-a4cc-c1e98bf28e4d |
+   +--------------------------------------+--------------------------------------+-----------+---------------------+-----------------------------------------------+
+
+
+``clusters export-jobs delete``
+===============================
+
+.. argparse::
+   :module: croud.__main__
+   :func: get_parser
+   :prog: croud
+   :path: clusters export-jobs delete
+
+Example
+-------
+
+.. code-block:: console
+
+   sh$ ❯ croud clusters export-jobs delete \
+         --cluster-id f6c39580-5719-431d-a508-0cee4f9e8209 \
+         --export-job-id 3b311ba9d-9cb4-404a-b58d-c442ae251dbf
+   ==> Success: Success.
+
 .. _here: https://hub.docker.com/r/crate/crate/tags

--- a/docs/commands/organizations.rst
+++ b/docs/commands/organizations.rst
@@ -234,3 +234,82 @@ Example
        --org-id f6c39580-5719-431d-a508-0cee4f9e8209 \
        --user john.doe@example.io
    ==> Success: User removed from organization.
+
+
+``organizations files``
+=======================
+
+.. argparse::
+   :module: croud.__main__
+   :func: get_parser
+   :prog: croud
+   :path: organizations files
+   :nosubcommands:
+
+
+``organizations files list``
+----------------------------
+
+.. argparse::
+   :module: croud.__main__
+   :func: get_parser
+   :prog: croud
+   :path: organizations files list
+
+Example
+.......
+
+.. code-block:: console
+
+   sh$ croud organizations files list \
+       --org-id f6c39580-5719-431d-a508-0cee4f9e8209
+   +--------------------------------------+---------------------+----------+
+   | id                                   | name                | status   |
+   |--------------------------------------+---------------------+----------|
+   | 9b5d438f-036c-410f-b6f4-9adfb1feb252 | nyc_taxi            | UPLOADED |
+   +--------------------------------------+---------------------+----------+
+
+
+``organizations files delete``
+------------------------------
+
+.. argparse::
+   :module: croud.__main__
+   :func: get_parser
+   :prog: croud
+   :path: organizations files delete
+
+Example
+.......
+
+.. code-block:: console
+
+   sh$ croud organizations files delete \
+       --org-id f6c39580-5719-431d-a508-0cee4f9e8209 \
+       --file-id 327ad0e6-607f-4f99-a4cc-c1e98bf28e4d
+   ==> Success: File upload deleted.
+
+
+``organizations files get``
+------------------------------
+
+.. argparse::
+   :module: croud.__main__
+   :func: get_parser
+   :prog: croud
+   :path: organizations files get
+
+Example
+.......
+
+.. code-block:: console
+
+   sh$ croud organizations files get \
+       --org-id f6c39580-5719-431d-a508-0cee4f9e8209 \
+       --file-id 327ad0e6-607f-4f99-a4cc-c1e98bf28e4d
+   +--------------------------------------+----------+----------+-------------+-------------------------------------------------------------+
+   | id                                   | name     | status   | file_size   | download_url                                                |
+   |--------------------------------------+----------+----------+-------------+-------------------------------------------------------------|
+   | 327ad0e6-607f-4f99-a4cc-c1e98bf28e4d | nyc_taxi | UPLOADED | 107.56 MiB  | https://cratedb-file-uploads.s3.amazonaws.com/some/download |
+   +--------------------------------------+----------+----------+-------------+-------------------------------------------------------------+
+

--- a/tests/commands/test_organizations.py
+++ b/tests/commands/test_organizations.py
@@ -374,6 +374,27 @@ def test_role_fqn_transform():
 
 
 @mock.patch.object(Client, "request", return_value=({}, None))
+def test_organizations_files_get(mock_request):
+    org_id = gen_uuid()
+    file_id = gen_uuid()
+    call_command(
+        "croud",
+        "organizations",
+        "files",
+        "get",
+        "--org-id",
+        org_id,
+        "--file-id",
+        file_id,
+    )
+    assert_rest(
+        mock_request,
+        RequestMethod.GET,
+        f"/api/v2/organizations/{org_id}/files/{file_id}/",
+    )
+
+
+@mock.patch.object(Client, "request", return_value=({}, None))
 def test_organizations_files_list(mock_request):
     org_id = gen_uuid()
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
This adds the following commands that allow organization admins to export data from crateDB and manage these export jobs.
- `$ croud clusters export-jobs create --cluster-id {cluster_id} --table {table} --file-format {format}` - exports data from the given table in the given format and displays a link to download the exported file.
![image](https://github.com/crate/croud/assets/44063937/d706d6f3-e6df-45ac-bcb6-cf70f46cde7e)
- `$ croud clusters export-jobs create --cluster-id {cluster_id} --table {table} --file-format {format} --save-as {target_file}` - exports data from the given table in the given format and downloads the file to the given location
![image](https://github.com/crate/croud/assets/44063937/806f8d18-777f-44ca-a8ad-444e865af206)
- `$ croud clusters export-jobs list --cluster-id {cluster_id}` - lists all export jobs for the given cluster
![image](https://github.com/crate/croud/assets/44063937/fe5cefdf-bcee-44eb-be51-a639c9b710bf)
- `$ croud clusters export-jobs delete --cluster-id {cluster_id} --export-job-id {export_job_id}` - deletes the given export job
- `$ croud organizations files get --org-id {org_id} --file-id {file_id}` - gets the details (e.g. `download_url`) for a given file
![image](https://github.com/crate/croud/assets/44063937/1f724bba-f90e-4dd3-b14c-916143340aa8)

https://github.com/crate/cloud/issues/1298
## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
