### PR TITLE
Prepare release 1.8.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for croud
 Unreleased
 ==========
 
+1.8.0 - 2023/11/07
+==================
+
 - Added support for listing, deleting and creating organization secrets.
 
 - Added support in import jobs for private S3 files using organization secrets.

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@
 from pkg_resources.extern.packaging.version import Version
 from setuptools import find_packages, setup
 
-__version__ = Version("1.7.0")
+__version__ = Version("1.8.0")
 
 try:
     with open("README.rst", "r", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
- Added support for listing, deleting and creating organization secrets.

- Added support in import jobs for private S3 files using organization secrets.

- Added documentation for all import jobs commands.

- Fixed ``import-job create from-url`` throwing an error despite working.

- Added support for showing import job progress.

- Added the ``--transformations`` argument for import jobs.

- Moved import and export jobs into their own section in croud docs.

- Fixed a bug preventing s3 imports from working (due to the endpoint).

- Correctly showing percent for import jobs, and not showing for export jobs.

## Checklist

 - [ ] Link to issue this PR refers to (if applicable): 
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
