### PR TITLE
Support for Azure secrets and blob Storage import jobs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ Unreleased
 
 - Added support for organization secrets of type Azure.
 
+- Added support for importing jobs from Azure Blob Storage.
+
 1.8.0 - 2023/11/07
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Unreleased
 - Added new resource ``organizations credits`` and subcommands that allow
   superusers to manage credits.
 
+- Added support for organization secrets of type Azure.
+
 1.8.0 - 2023/11/07
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,15 +5,15 @@ Changes for croud
 Unreleased
 ==========
 
+- Added support for organization secrets of type Azure.
+
+- Added support for importing jobs from Azure Blob Storage.
+
 1.9.0 - 2023/12/04
 ==================
 
 - Added new resource ``organizations credits`` and subcommands that allow
   superusers to manage credits.
-
-- Added support for organization secrets of type Azure.
-
-- Added support for importing jobs from Azure Blob Storage.
 
 1.8.0 - 2023/11/07
 ==================

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -51,6 +51,7 @@ from croud.clusters.commands import (
     export_jobs_delete,
     export_jobs_list,
     import_job_progress,
+    import_jobs_create_from_azure_blob_storage,
     import_jobs_create_from_file,
     import_jobs_create_from_s3,
     import_jobs_create_from_url,
@@ -809,7 +810,8 @@ command_tree = {
                                     Argument(
                                         "--file-path", type=str, required=True,
                                         help="The absolute path in the S3 bucket that "
-                                             "points to the file to be imported."
+                                             "points to the file to be imported. "
+                                             "Globbing (use of *) is allowed."
                                     ),
                                     Argument(
                                         "--secret-id", type=str, required=True,
@@ -823,6 +825,32 @@ command_tree = {
                                     ),
                                 ] + import_job_create_common_args,
                                 "resolver": import_jobs_create_from_s3,
+                            },
+                            "from-azure-blob-storage": {
+                                "help": "Create a data import job on the specified "
+                                        "cluster from an Azure blob storage location.",
+                                "extra_args": [
+                                    # Type Azure Blob Storage params
+                                    Argument(
+                                        "--container-name", type=str,
+                                        required=True,
+                                        help="The name of the storage container "
+                                             "where the file to be imported is located."
+                                    ),
+                                    Argument(
+                                        "--blob-name", type=str, required=True,
+                                        help="The absolute path in the storage "
+                                             "container that points to the file to be "
+                                             "imported. Globbing (use of *) is allowed."
+                                    ),
+                                    Argument(
+                                        "--secret-id", type=str, required=True,
+                                        help="The secret that contains the access key "
+                                             "and secret key needed to access the file "
+                                             "to be imported."
+                                    ),
+                                ] + import_job_create_common_args,
+                                "resolver": import_jobs_create_from_azure_blob_storage,
                             },
                         },
                     },

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -1114,17 +1114,24 @@ command_tree = {
                                 help="The name the secret will be known as.",
                             ),
                             Argument(
-                                "--type", type=str, required=True, choices=["AWS"],
-                                help="The type of Secret. Currently only AWS type is "
-                                     "supported.",
+                                "--type", type=str, required=True,
+                                choices=["AWS", "azure"],
+                                help="The type of Secret. Either AWS or Azure.",
                             ),
+                            # AWS arguments
                             Argument(
-                                "--access-key", type=str, required=True,
+                                "--access-key", type=str, required=False,
                                 help="For an AWS type secret, the access key ID.",
                             ),
                             Argument(
-                                "--secret-key", type=str, required=True,
+                                "--secret-key", type=str, required=False,
                                 help="For an AWS type secret, the secret key.",
+                            ),
+                            # Azure arguments
+                            Argument(
+                                "--connection-string", type=str, required=False,
+                                help="For an Azure type secret, the connection string "
+                                     "or URL that grants access to a resource.",
                             ),
                         ],
                         "resolver": org_secrets_create,

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -1143,7 +1143,7 @@ command_tree = {
                             ),
                             Argument(
                                 "--type", type=str, required=True,
-                                choices=["AWS", "azure"],
+                                choices=["AWS", "AZURE"],
                                 help="The type of Secret. Either AWS or Azure.",
                             ),
                             # AWS arguments

--- a/croud/clusters/commands.py
+++ b/croud/clusters/commands.py
@@ -200,6 +200,18 @@ def import_jobs_create_from_s3(args: Namespace) -> None:
     import_jobs_create(args, extra_payload=extra_body)
 
 
+def import_jobs_create_from_azure_blob_storage(args: Namespace) -> None:
+    extra_body = {
+        "azureblob": {
+            "container_name": args.container_name,
+            "blob_name": args.blob_name,
+            "secret_id": args.secret_id,
+        }
+    }
+    args.type = "azureblob"
+    import_jobs_create(args, extra_payload=extra_body)
+
+
 def _get_org_id_from_cluster_id(client, cluster_id: str) -> Optional[str]:
     data, errors = client.get(f"/api/v2/clusters/{cluster_id}/")
     if errors or not data:

--- a/croud/organizations/commands.py
+++ b/croud/organizations/commands.py
@@ -162,11 +162,26 @@ def org_secrets_create(args: Namespace) -> None:
     payload = {
         "name": args.name,
         "type": args.type,
-        "data": {
+    }
+
+    if args.type == "AWS":
+        if not args.access_key or not args.secret_key:
+            print_error(
+                "Both access_key and secret_key are required for secret type AWS."
+            )
+            return
+        payload["data"] = {
             "access_key": args.access_key,
             "secret_key": args.secret_key,
-        },
-    }
+        }
+    elif args.type == "azure":
+        if not args.connection_string:
+            print_error("Argument connection-string is required for secret type Azure.")
+            return
+        payload["data"] = {
+            "connection_string": args.connection_string,
+        }
+
     data, errors = client.post(
         f"/api/v2/organizations/{args.org_id}/secrets/", body=payload
     )

--- a/croud/organizations/commands.py
+++ b/croud/organizations/commands.py
@@ -174,12 +174,14 @@ def org_secrets_create(args: Namespace) -> None:
             "access_key": args.access_key,
             "secret_key": args.secret_key,
         }
-    elif args.type == "azure":
+    elif args.type == "AZURE":
         if not args.connection_string:
             print_error("Argument connection-string is required for secret type Azure.")
             return
         payload["data"] = {
-            "connection_string": args.connection_string,
+            "azure_secret": {
+                "connection_string": args.connection_string,
+            }
         }
 
     data, errors = client.post(

--- a/tests/commands/test_organizations.py
+++ b/tests/commands/test_organizations.py
@@ -464,7 +464,7 @@ def test_organizations_secrets_list(mock_request):
 
 
 @mock.patch.object(Client, "request", return_value=({}, None))
-def test_organizations_secrets_create(mock_request):
+def test_organizations_secrets_aws_create(mock_request):
     org_id = gen_uuid()
     name = "my_secret"
     secret_type = "AWS"
@@ -495,6 +495,39 @@ def test_organizations_secrets_create(mock_request):
             "name": name,
             "type": secret_type,
             "data": {"access_key": access_key, "secret_key": secret_key},
+        },
+    )
+
+
+@mock.patch.object(Client, "request", return_value=({}, None))
+def test_organizations_secrets_azure_create(mock_request):
+    org_id = gen_uuid()
+    name = "my_secret"
+    secret_type = "azure"
+    connection_string = "my_connection_string"
+
+    call_command(
+        "croud",
+        "organizations",
+        "secrets",
+        "create",
+        "--org-id",
+        org_id,
+        "--name",
+        name,
+        "--type",
+        secret_type,
+        "--connection-string",
+        connection_string,
+    )
+    assert_rest(
+        mock_request,
+        RequestMethod.POST,
+        f"/api/v2/organizations/{org_id}/secrets/",
+        body={
+            "name": name,
+            "type": secret_type,
+            "data": {"connection_string": connection_string},
         },
     )
 

--- a/tests/commands/test_organizations.py
+++ b/tests/commands/test_organizations.py
@@ -503,8 +503,8 @@ def test_organizations_secrets_aws_create(mock_request):
 def test_organizations_secrets_azure_create(mock_request):
     org_id = gen_uuid()
     name = "my_secret"
-    secret_type = "azure"
-    connection_string = "my_connection_string"
+    secret_type = "AZURE"
+    connection_string = "https://my-storage-account.blob.core.windows.net/my-container?my-auth-params"  # noqa
 
     call_command(
         "croud",
@@ -527,7 +527,9 @@ def test_organizations_secrets_azure_create(mock_request):
         body={
             "name": name,
             "type": secret_type,
-            "data": {"connection_string": connection_string},
+            "data": {
+                "azure_secret": {"connection_string": connection_string},
+            },
         },
     )
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
- Added support for organization secrets of type Azure.
- Added support for importing jobs from Azure Blob Storage.


## Checklist

 - [x] Link to issue this PR refers to (if applicable): https://github.com/crate/cloud/issues/1505
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
