### PR TITLE
Import jobs can now optionally add columns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for croud
 Unreleased
 ==========
 
+- Import jobs can now optionally add columns to the schema if the `create_table`
+  parameter is set to `true`.
+
 1.10.0 - 2023/12/21
 ===================
 

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -152,7 +152,8 @@ import_job_create_common_args = [
         type=lambda x: bool(strtobool(str(x))),  # noqa
         required=False,
         help="Whether the table should be created automatically"
-        " if it does not exist.",
+        " if it does not exist. If true new columns will also be added when the data"
+        " requires them.",
     ),
     Argument(
         "--transformations",


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Changed the documentation strings to describe the new behaviour of the `create_table` parameter.

## Checklist

 - [x] Link to issue this PR refers to (if applicable): https://github.com/crate/cloud/issues/1546
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
