### PR TITLE
Prepare release 1.10.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for croud
 Unreleased
 ==========
 
+1.10.1 - 2024/01/11
+===================
+
 - Import jobs can now optionally add columns to the schema if the `create_table`
   parameter is set to `true`.
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@
 from pkg_resources.extern.packaging.version import Version
 from setuptools import find_packages, setup
 
-__version__ = Version("1.10.0")
+__version__ = Version("1.10.1")
 
 try:
     with open("README.rst", "r", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
- Import jobs can now optionally add columns to the schema if the `create_table`
  parameter is set to `true`.

## Checklist

 - [ ] Link to issue this PR refers to (if applicable): 
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
