### PR TITLE
Add commands to manage cloud-configurations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ Unreleased
 
 - Added support for scheduling sql jobs with the ``scheduled-jobs`` commands.
 
+- Added command ``croud cloud-configurations`` that allows superusers to manage
+  configuration settings of CrateDB Cloud.
+
 1.10.1 - 2024/01/11
 ===================
 

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -31,6 +31,11 @@ from croud.apikeys.commands import (
     api_keys_edit,
     api_keys_list,
 )
+from croud.cloud_configurations.commands import (
+    cloud_configurations_get,
+    cloud_configurations_list,
+    cloud_configurations_set,
+)
 from croud.clusters.commands import (
     clusters_delete,
     clusters_deploy,
@@ -1632,6 +1637,64 @@ command_tree = {
             },
         },
     },
+    "cloud-configurations": {
+        "help": "Manage configurations of CrateDB Cloud.",
+        "commands": {
+            "set": {
+                "help": (
+                    "Set a configuration key/value. This command "
+                    "is for superusers only."
+                ),
+                "extra_args": [
+                    Argument(
+                        "--key", type=str, required=True,
+                        help="The configuration key to set.",
+                    ),
+                    Argument(
+                        "--value", type=str, required=True,
+                        help="The configuration value to use.",
+                    ),
+                    Argument(
+                        "--org-id", type=str, required=False,
+                        help="Override the value for a single organization only.",
+                    ),
+                ],
+                "resolver": cloud_configurations_set,
+            },
+            "get": {
+                "help": (
+                    "Get the configuration value by its key. This command "
+                    "is for superusers only."
+                ),
+                "extra_args": [
+                    Argument(
+                        "--key", type=str, required=True,
+                        help="The configuration key to get.",
+                    ),
+                    Argument(
+                        "--org-id", type=str, required=False,
+                        help="Optionally get the value for a certain organization. "
+                             "Defaults to the global configuration value.",
+                    ),
+                ],
+                "resolver": cloud_configurations_get,
+            },
+            "list": {
+                "help": (
+                    "List all cloud configurations. This command "
+                    "is for superusers only."
+                ),
+                "extra_args": [
+                    Argument(
+                        "--org-id", type=str, required=False,
+                        help="Optionally get the values for a certain organization. "
+                             "Defaults to the global configuration values.",
+                    ),
+                ],
+                "resolver": cloud_configurations_list,
+            }
+        },
+    }
 }
 # fmt: on
 

--- a/croud/cloud_configurations/commands.py
+++ b/croud/cloud_configurations/commands.py
@@ -1,0 +1,75 @@
+# Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+from argparse import Namespace
+
+from croud.api import Client
+from croud.config import get_output_format
+from croud.printer import print_response
+
+
+def _org_id_transform(field):
+    return field or ""
+
+
+def cloud_configurations_set(args: Namespace) -> None:
+    body = {"value": args.value}
+    if args.org_id:
+        body["organization_id"] = args.org_id
+
+    client = Client.from_args(args)
+    data, errors = client.put(f"/api/v2/configurations/{args.key}/", body=body)
+    print_response(
+        data=data,
+        errors=errors,
+        keys=["key", "value", "organization_id"],
+        success_message="Configuration updated.",
+        output_fmt=get_output_format(args),
+        transforms={"organization_id": _org_id_transform},
+    )
+
+
+def cloud_configurations_get(args: Namespace) -> None:
+    client = Client.from_args(args)
+    params = {}
+    if args.org_id:
+        params["organization_id"] = args.org_id
+    data, errors = client.get(f"/api/v2/configurations/{args.key}/", params=params)
+    print_response(
+        data=data,
+        errors=errors,
+        keys=["key", "value", "organization_id"],
+        output_fmt=get_output_format(args),
+        transforms={"organization_id": _org_id_transform},
+    )
+
+
+def cloud_configurations_list(args: Namespace) -> None:
+    client = Client.from_args(args)
+    params = {}
+    if args.org_id:
+        params["organization_id"] = args.org_id
+    data, errors = client.get("/api/v2/configurations/", params=params)
+    print_response(
+        data=data,
+        errors=errors,
+        keys=["key", "value", "organization_id"],
+        output_fmt=get_output_format(args),
+        transforms={"organization_id": _org_id_transform},
+    )

--- a/docs/commands/cloud-configurations.rst
+++ b/docs/commands/cloud-configurations.rst
@@ -1,0 +1,104 @@
+========================
+``cloud-configurations``
+========================
+
+The ``cloud-configurations`` command allows you to list, get and set configuration
+keys of CrateDB Cloud.
+
+.. argparse::
+   :module: croud.__main__
+   :func: get_parser
+   :prog: croud
+   :path: cloud-configurations
+   :nosubcommands:
+
+
+``cloud-configurations list``
+=============================
+
+    Lists all configurations of CrateDB Cloud. Optionally it returns org specific values.
+
+.. argparse::
+   :module: croud.__main__
+   :func: get_parser
+   :prog: croud
+   :path: cloud-configurations list
+
+Example
+-------
+
+.. code-block:: console
+
+   sh$ croud cloud-configurations list \
+       --org-id f6c39580-5719-431d-a508-0cee4f9e8209 --sudo
+   +-------------------------------------------------+-------------+--------------------------------------+
+   | key                                             | value       | organization_id                      |
+   |-------------------------------------------------+-------------+--------------------------------------|
+   | CRATEDB_CLOUD_SETTING_ONE                       | 100         |                                      |
+   | CRATEDB_CLOUD_SETTING_ORG_SPECIFIC              | 1024        | f6c39580-5719-431d-a508-0cee4f9e8209 |
+   | CRATEDB_CLOUD_SETTING_THREE                     | 30          |                                      |
+   +-------------------------------------------------+-------------+--------------------------------------+
+
+.. note::
+
+   This command is only available for superusers.
+
+
+``cloud-configurations get``
+============================
+
+    Get a single configuration value of CrateDB Cloud. Optionally it returns the org specific value.
+
+.. argparse::
+   :module: croud.__main__
+   :func: get_parser
+   :prog: croud
+   :path: cloud-configurations get
+   :nosubcommands:
+
+.. code-block:: console
+
+   sh$ croud cloud-configurations get \
+       --key CRATEDB_CLOUD_SETTING_ORG_SPECIFIC \
+       --org-id f6c39580-5719-431d-a508-0cee4f9e8209 \
+       --sudo
+   +-------------------------------------------------+-------------+--------------------------------------+
+   | key                                             | value       | organization_id                      |
+   |-------------------------------------------------+-------------+--------------------------------------|
+   | CRATEDB_CLOUD_SETTING_ORG_SPECIFIC              | 1024        | f6c39580-5719-431d-a508-0cee4f9e8209 |
+   +-------------------------------------------------+-------------+--------------------------------------+
+
+.. note::
+
+   This command is only available for superusers.
+
+
+``cloud-configurations set``
+============================
+
+    Set a configuration value of CrateDB Cloud either globally or for a single organization only.
+
+.. argparse::
+   :module: croud.__main__
+   :func: get_parser
+   :prog: croud
+   :path: cloud-configurations set
+   :nosubcommands:
+
+.. code-block:: console
+
+   sh$ croud cloud-configurations set \
+       --key CRATEDB_CLOUD_SETTING_ORG_SPECIFIC \
+       --value 2048 \
+       --org-id f6c39580-5719-431d-a508-0cee4f9e8209 \
+       --sudo
+   +-------------------------------------------------+-------------+--------------------------------------+
+   | key                                             | value       | organization_id                      |
+   |-------------------------------------------------+-------------+--------------------------------------|
+   | CRATEDB_CLOUD_SETTING_ORG_SPECIFIC              | 2048        | f6c39580-5719-431d-a508-0cee4f9e8209 |
+   +-------------------------------------------------+-------------+--------------------------------------+
+   ==> Success: Configuration updated.
+
+.. note::
+
+   This command is only available for superusers.

--- a/docs/commands/index.rst
+++ b/docs/commands/index.rst
@@ -47,6 +47,7 @@ To get help for a specific command, you can append ``--help``:
    api-keys
    regions
    scheduled-jobs
+   cloud-configurations
 
 .. note::
 

--- a/tests/commands/test_cloud_configurations.py
+++ b/tests/commands/test_cloud_configurations.py
@@ -1,0 +1,58 @@
+from unittest import mock
+
+from croud.api import Client, RequestMethod
+from tests.util import assert_rest, call_command, gen_uuid
+
+
+@mock.patch.object(Client, "request", return_value=({}, None))
+def test_cloud_configurations_get(mock_request):
+    org_id = gen_uuid()
+    call_command(
+        "croud",
+        "cloud-configurations",
+        "get",
+        "--key",
+        "my_config_key",
+        "--org-id",
+        org_id,
+    )
+    assert_rest(
+        mock_request,
+        RequestMethod.GET,
+        "/api/v2/configurations/my_config_key/",
+        params={"organization_id": org_id},
+    )
+
+
+@mock.patch.object(Client, "request", return_value=({}, None))
+def test_cloud_configurations_set(mock_request):
+    org_id = gen_uuid()
+    call_command(
+        "croud",
+        "cloud-configurations",
+        "set",
+        "--key",
+        "my_config_key",
+        "--value",
+        "new_config_value",
+        "--org-id",
+        org_id,
+    )
+    assert_rest(
+        mock_request,
+        RequestMethod.PUT,
+        "/api/v2/configurations/my_config_key/",
+        body={"value": "new_config_value", "organization_id": org_id},
+    )
+
+
+@mock.patch.object(Client, "request", return_value=({}, None))
+def test_cloud_configurations_list(mock_request):
+    org_id = gen_uuid()
+    call_command("croud", "cloud-configurations", "list", "--org-id", org_id)
+    assert_rest(
+        mock_request,
+        RequestMethod.GET,
+        "/api/v2/configurations/",
+        params={"organization_id": org_id},
+    )


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Add superuser commands to manage cloud configurations
- `croud cloud-configurations list --sudo [--org-id ORG_ID]` lists all available configuration keys/values. Optionally with org specific overrides.
- `croud cloud-configurations get --key KEY --sudo [--org-id ORG_ID]` get the value of a single configuration key. Optionally with org specific overrides.
- `croud cloud-configurations set --key KEY --value VALUE --sudo [--org-id ORG_ID]` set the value of a configuration key globally or create an org override if an `org-id` is set.

## Checklist

 - [x] Link to issue this PR refers to (if applicable): https://github.com/crate/cloud/issues/1682
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
