### PR TITLE
Prepare release 1.11.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for croud
 Unreleased
 ==========
 
+1.11.1 - 2024/04/11
+===================
+
 - Update doc for ``clusters restart-node`` because it is not superuser only anymore.
 
 - Upgrade docs build action Python version to 3.11.

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@
 from pkg_resources.extern.packaging.version import Version
 from setuptools import find_packages, setup
 
-__version__ = Version("1.11.0")
+__version__ = Version("1.11.1")
 
 try:
     with open("README.rst", "r", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
- Prepare release 1.11.1
- Update doc for ``clusters restart-node`` because it is not superuser only anymore.
- Upgrade docs build action Python version to 3.11.

## Checklist

 - [ ] Link to issue this PR refers to (if applicable): 
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
