### PR TITLE
Add support for overriding cloud-configurations per user

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changes for croud
 Unreleased
 ==========
 
+- Added support for overriding cloud-configurations per user.
+
 1.11.1 - 2024/04/11
 ===================
 

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -1658,6 +1658,10 @@ command_tree = {
                         "--org-id", type=str, required=False,
                         help="Override the value for a single organization only.",
                     ),
+                    Argument(
+                        "--user-id", type=str, required=False,
+                        help="Override the value for a single user only.",
+                    ),
                 ],
                 "resolver": cloud_configurations_set,
             },
@@ -1676,6 +1680,11 @@ command_tree = {
                         help="Optionally get the value for a certain organization. "
                              "Defaults to the global configuration value.",
                     ),
+                    Argument(
+                        "--user-id", type=str, required=False,
+                        help="Optionally get the value for a certain user. "
+                             "Defaults to the global configuration value.",
+                    ),
                 ],
                 "resolver": cloud_configurations_get,
             },
@@ -1688,6 +1697,11 @@ command_tree = {
                     Argument(
                         "--org-id", type=str, required=False,
                         help="Optionally get the values for a certain organization. "
+                             "Defaults to the global configuration values.",
+                    ),
+                    Argument(
+                        "--user-id", type=str, required=False,
+                        help="Optionally get the values for a certain user. "
                              "Defaults to the global configuration values.",
                     ),
                 ],

--- a/croud/cloud_configurations/commands.py
+++ b/croud/cloud_configurations/commands.py
@@ -24,7 +24,7 @@ from croud.config import get_output_format
 from croud.printer import print_response
 
 
-def _org_id_transform(field):
+def _override_id_transform(field):
     return field or ""
 
 
@@ -32,16 +32,21 @@ def cloud_configurations_set(args: Namespace) -> None:
     body = {"value": args.value}
     if args.org_id:
         body["organization_id"] = args.org_id
+    elif args.user_id:
+        body["user_id"] = args.user_id
 
     client = Client.from_args(args)
     data, errors = client.put(f"/api/v2/configurations/{args.key}/", body=body)
     print_response(
         data=data,
         errors=errors,
-        keys=["key", "value", "organization_id"],
+        keys=["key", "value", "organization_id", "user_id"],
         success_message="Configuration updated.",
         output_fmt=get_output_format(args),
-        transforms={"organization_id": _org_id_transform},
+        transforms={
+            "organization_id": _override_id_transform,
+            "user_id": _override_id_transform,
+        },
     )
 
 
@@ -50,13 +55,18 @@ def cloud_configurations_get(args: Namespace) -> None:
     params = {}
     if args.org_id:
         params["organization_id"] = args.org_id
+    elif args.user_id:
+        params["user_id"] = args.user_id
     data, errors = client.get(f"/api/v2/configurations/{args.key}/", params=params)
     print_response(
         data=data,
         errors=errors,
-        keys=["key", "value", "organization_id"],
+        keys=["key", "value", "organization_id", "user_id"],
         output_fmt=get_output_format(args),
-        transforms={"organization_id": _org_id_transform},
+        transforms={
+            "organization_id": _override_id_transform,
+            "user_id": _override_id_transform,
+        },
     )
 
 
@@ -65,11 +75,16 @@ def cloud_configurations_list(args: Namespace) -> None:
     params = {}
     if args.org_id:
         params["organization_id"] = args.org_id
+    elif args.user_id:
+        params["user_id"] = args.user_id
     data, errors = client.get("/api/v2/configurations/", params=params)
     print_response(
         data=data,
         errors=errors,
-        keys=["key", "value", "organization_id"],
+        keys=["key", "value", "organization_id", "user_id"],
         output_fmt=get_output_format(args),
-        transforms={"organization_id": _org_id_transform},
+        transforms={
+            "organization_id": _override_id_transform,
+            "user_id": _override_id_transform,
+        },
     )

--- a/docs/commands/cloud-configurations.rst
+++ b/docs/commands/cloud-configurations.rst
@@ -16,7 +16,7 @@ keys of CrateDB Cloud.
 ``cloud-configurations list``
 =============================
 
-    Lists all configurations of CrateDB Cloud. Optionally it returns org specific values.
+    Lists all configurations of CrateDB Cloud. Optionally it returns org or user specific values.
 
 .. argparse::
    :module: croud.__main__
@@ -31,13 +31,13 @@ Example
 
    sh$ croud cloud-configurations list \
        --org-id f6c39580-5719-431d-a508-0cee4f9e8209 --sudo
-   +-------------------------------------------------+-------------+--------------------------------------+
-   | key                                             | value       | organization_id                      |
-   |-------------------------------------------------+-------------+--------------------------------------|
-   | CRATEDB_CLOUD_SETTING_ONE                       | 100         |                                      |
-   | CRATEDB_CLOUD_SETTING_ORG_SPECIFIC              | 1024        | f6c39580-5719-431d-a508-0cee4f9e8209 |
-   | CRATEDB_CLOUD_SETTING_THREE                     | 30          |                                      |
-   +-------------------------------------------------+-------------+--------------------------------------+
+   +-------------------------------------------------+-------------+--------------------------------------+-----------+
+   | key                                             | value       | organization_id                      | user_id   |
+   |-------------------------------------------------+-------------+--------------------------------------|-----------|
+   | CRATEDB_CLOUD_SETTING_ONE                       | 100         |                                      |           |
+   | CRATEDB_CLOUD_SETTING_ORG_SPECIFIC              | 1024        | f6c39580-5719-431d-a508-0cee4f9e8209 |           |
+   | CRATEDB_CLOUD_SETTING_THREE                     | 30          |                                      |           |
+   +-------------------------------------------------+-------------+--------------------------------------+-----------+
 
 .. note::
 
@@ -47,7 +47,7 @@ Example
 ``cloud-configurations get``
 ============================
 
-    Get a single configuration value of CrateDB Cloud. Optionally it returns the org specific value.
+    Get a single configuration value of CrateDB Cloud. Optionally it returns the org or user specific value.
 
 .. argparse::
    :module: croud.__main__
@@ -62,11 +62,11 @@ Example
        --key CRATEDB_CLOUD_SETTING_ORG_SPECIFIC \
        --org-id f6c39580-5719-431d-a508-0cee4f9e8209 \
        --sudo
-   +-------------------------------------------------+-------------+--------------------------------------+
-   | key                                             | value       | organization_id                      |
-   |-------------------------------------------------+-------------+--------------------------------------|
-   | CRATEDB_CLOUD_SETTING_ORG_SPECIFIC              | 1024        | f6c39580-5719-431d-a508-0cee4f9e8209 |
-   +-------------------------------------------------+-------------+--------------------------------------+
+   +-------------------------------------------------+-------------+--------------------------------------+-----------+
+   | key                                             | value       | organization_id                      | user_id   |
+   |-------------------------------------------------+-------------+--------------------------------------|-----------|
+   | CRATEDB_CLOUD_SETTING_ORG_SPECIFIC              | 1024        | f6c39580-5719-431d-a508-0cee4f9e8209 |           |
+   +-------------------------------------------------+-------------+--------------------------------------+-----------+
 
 .. note::
 
@@ -76,7 +76,7 @@ Example
 ``cloud-configurations set``
 ============================
 
-    Set a configuration value of CrateDB Cloud either globally or for a single organization only.
+    Set a configuration value of CrateDB Cloud either globally or for a single organization or user only.
 
 .. argparse::
    :module: croud.__main__
@@ -92,11 +92,11 @@ Example
        --value 2048 \
        --org-id f6c39580-5719-431d-a508-0cee4f9e8209 \
        --sudo
-   +-------------------------------------------------+-------------+--------------------------------------+
-   | key                                             | value       | organization_id                      |
-   |-------------------------------------------------+-------------+--------------------------------------|
-   | CRATEDB_CLOUD_SETTING_ORG_SPECIFIC              | 2048        | f6c39580-5719-431d-a508-0cee4f9e8209 |
-   +-------------------------------------------------+-------------+--------------------------------------+
+   +-------------------------------------------------+-------------+--------------------------------------+-----------+
+   | key                                             | value       | organization_id                      | user_id   |
+   |-------------------------------------------------+-------------+--------------------------------------|-----------|
+   | CRATEDB_CLOUD_SETTING_ORG_SPECIFIC              | 2048        | f6c39580-5719-431d-a508-0cee4f9e8209 |           |
+   +-------------------------------------------------+-------------+--------------------------------------+-----------+
    ==> Success: Configuration updated.
 
 .. note::

--- a/tests/commands/test_cloud_configurations.py
+++ b/tests/commands/test_cloud_configurations.py
@@ -5,7 +5,7 @@ from tests.util import assert_rest, call_command, gen_uuid
 
 
 @mock.patch.object(Client, "request", return_value=({}, None))
-def test_cloud_configurations_get(mock_request):
+def test_cloud_configurations_get_org_override(mock_request):
     org_id = gen_uuid()
     call_command(
         "croud",
@@ -25,7 +25,7 @@ def test_cloud_configurations_get(mock_request):
 
 
 @mock.patch.object(Client, "request", return_value=({}, None))
-def test_cloud_configurations_set(mock_request):
+def test_cloud_configurations_set_org_override(mock_request):
     org_id = gen_uuid()
     call_command(
         "croud",
@@ -47,7 +47,7 @@ def test_cloud_configurations_set(mock_request):
 
 
 @mock.patch.object(Client, "request", return_value=({}, None))
-def test_cloud_configurations_list(mock_request):
+def test_cloud_configurations_list_org_override(mock_request):
     org_id = gen_uuid()
     call_command("croud", "cloud-configurations", "list", "--org-id", org_id)
     assert_rest(
@@ -55,4 +55,58 @@ def test_cloud_configurations_list(mock_request):
         RequestMethod.GET,
         "/api/v2/configurations/",
         params={"organization_id": org_id},
+    )
+
+
+@mock.patch.object(Client, "request", return_value=({}, None))
+def test_cloud_configurations_get_user_override(mock_request):
+    user_id = gen_uuid()
+    call_command(
+        "croud",
+        "cloud-configurations",
+        "get",
+        "--key",
+        "my_config_key",
+        "--user-id",
+        user_id,
+    )
+    assert_rest(
+        mock_request,
+        RequestMethod.GET,
+        "/api/v2/configurations/my_config_key/",
+        params={"user_id": user_id},
+    )
+
+
+@mock.patch.object(Client, "request", return_value=({}, None))
+def test_cloud_configurations_set_user_override(mock_request):
+    user_id = gen_uuid()
+    call_command(
+        "croud",
+        "cloud-configurations",
+        "set",
+        "--key",
+        "my_config_key",
+        "--value",
+        "new_config_value",
+        "--user-id",
+        user_id,
+    )
+    assert_rest(
+        mock_request,
+        RequestMethod.PUT,
+        "/api/v2/configurations/my_config_key/",
+        body={"value": "new_config_value", "user_id": user_id},
+    )
+
+
+@mock.patch.object(Client, "request", return_value=({}, None))
+def test_cloud_configurations_list_user_override(mock_request):
+    user_id = gen_uuid()
+    call_command("croud", "cloud-configurations", "list", "--user-id", user_id)
+    assert_rest(
+        mock_request,
+        RequestMethod.GET,
+        "/api/v2/configurations/",
+        params={"user_id": user_id},
     )


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
This adds an optional argument `--user-id` to `croud cloud-configurations get|set|list` to get or set user specific configuration values (similar to what is already done on organization level with the `--org-id` arg).

## Checklist

 - [x] Link to issue this PR refers to (if applicable): https://github.com/crate/cloud/issues/1828
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
