### PR TITLE
Add note for deploying free clusters

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence,
 # The users listed below are global owners and will be
 # requested for review when someone opens a pull request.
-*       @plaharanne @tomach @WalBeh @Taliik @juanpardo @SStorm
+*       @plaharanne @tomach @WalBeh @Taliik @juanpardo

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -493,7 +493,8 @@ command_tree = {
                     ),
                     Argument(
                         "--subscription-id", type=str, required=True,
-                        help="The subscription to use for billing of this cluster.",
+                        help="The subscription to use for billing of this cluster. Use "
+                             "``free_tier`` to deploy a free cluster.",
                     ),
                     Argument(
                         "--channel", type=str, default="stable", required=False,

--- a/docs/commands/clusters.rst
+++ b/docs/commands/clusters.rst
@@ -130,6 +130,11 @@ Example
        --channel nightly
        --unit 0
 
+.. note::
+
+   Free clusters can be deployed without a paid subscription. Therefore you can use
+   ``--subscription-id free_tier --product-name crfree``.
+
 
 ``clusters scale``
 ==================


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Added a note how to set `--subscription-id` argument when deploying free clusters.

## Checklist

 - [x] Link to issue this PR refers to (if applicable): https://github.com/crate/cloud/issues/1807
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
