### PR TITLE
Add `packaging` to github release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
           python-version: 3.8
       - name: Install setuptools and wheel
         run: |
-          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade pip setuptools wheel packaging
       - name: Build sdist and wheel
         run: |
           python setup.py sdist bdist_wheel


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Follow-up to https://github.com/crate/croud/pull/521 This should fix:
```
Traceback (most recent call last):
  File "setup.py", line 24, in <module>
    from packaging.version import Version
ModuleNotFoundError: No module named 'packaging'
```


## Checklist

 - [ ] Link to issue this PR refers to (if applicable): 
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
