### PR TITLE
Fix README.rst for pypi upload

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,25 +49,20 @@ Help
 
 .. |ci| image:: https://github.com/crate/croud/actions/workflows/docs.yml/badge.svg
     :alt: CI status
-    :scale: 100%
     :target: https://github.com/crate/croud/actions/workflows/docs.yml
 
 .. |coverage| image:: https://codecov.io/gh/crate/croud/branch/master/graph/badge.svg
     :alt: Code coverage
-    :scale: 100%
     :target: https://codecov.io/gh/crate/croud
 
 .. |rtd| image:: https://readthedocs.org/projects/croud/badge/?version=latest
     :alt: Read The Docs status
-    :scale: 100%
     :target: https://croud.readthedocs.io/en/latest/
 
 .. |pypi-version| image:: https://badge.fury.io/py/croud.svg
     :alt: Most recent version on PyPI
-    :scale: 100%
     :target: https://pypi.org/project/croud/
 
 .. |python-versions| image:: https://img.shields.io/pypi/pyversions/croud.svg
     :alt: Supported Python versions
-    :scale: 100%
     :target: https://pypi.org/project/croud/

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
     author_email="office@crate.io",
     url="https://github.com/crate/croud",
     description="A command line interface for CrateDB Cloud",
+    long_description_content_type="text/x-rst",
     long_description=readme,
     version=str(__version__),
     entry_points={"console_scripts": ["croud = croud.__main__:main"]},


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Pypi upload seems to fail when images have a `scale` factor. in this case `twine` reports:
```
$ twine check dist/*
Checking dist/croud-1.12.0-py2.py3-none-any.whl: FAILED
ERROR    `long_description` has syntax errors in markup and would not be rendered on PyPI.                                                                                                                          
         line 50: Warning: Cannot scale image!                                                                                                                                                                      
           Could not get size from "https://github.com/crate/croud/actions/workflows/docs.yml/badge.svg":                                                                                                           
           Requires Python Imaging Library.                                                                                                                                                                         
           Reading external files disabled.                                                                                                                                                                         
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.                                                                                                                                       
Checking dist/croud-1.12.0.tar.gz: FAILED
ERROR    `long_description` has syntax errors in markup and would not be rendered on PyPI.                                                                                                                          
         line 50: Warning: Cannot scale image!                                                                                                                                                                      
           Could not get size from "https://github.com/crate/croud/actions/workflows/docs.yml/badge.svg":                                                                                                           
           Requires Python Imaging Library.                                                                                                                                                                         
           Reading external files disabled.                                                                                                                                                                         
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.
```

## Checklist

 - [ ] Link to issue this PR refers to (if applicable): 
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
