### PR TITLE
Dependencies: Modernize to prepare unlocking more recent Python versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: '3.11'
       - name: Build docs
         run: |
           cd docs && make check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,9 +65,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .
-          python -m pip install -r test-requirements.txt
-          python -m pip install pytest-cov
+          python -m pip install --editable='.[testing]'
       - name: Run tests
         run: |
           pytest -vvv --cov=croud --cov-report=xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - 3.8
+        - '3.11'
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,10 +9,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up Python 3.8
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: '3.11'
       - name: Install setuptools and wheel
         run: |
           python -m pip install --upgrade pip setuptools wheel packaging

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.10"
+    python: "3.11"
 
 sphinx:
   builder: html

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Croud
 =====
 
-|ci| |coverage| |rtd| |pypi-version|
+|ci| |coverage| |rtd| |pypi-version| |python-versions|
 
 |
 

--- a/croud/__init__.py
+++ b/croud/__init__.py
@@ -17,6 +17,17 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
-import pkg_resources
+try:
+    from importlib.metadata import PackageNotFoundError, version
+except (ImportError, ModuleNotFoundError):  # pragma:nocover
+    from importlib_metadata import (  # type: ignore[assignment,no-redef,unused-ignore]
+        PackageNotFoundError,
+        version,
+    )
 
-__version__ = pkg_resources.require("croud")[0].version
+__appname__ = "croud"
+
+try:
+    __version__ = version(__appname__)
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "unknown"

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -20,7 +20,6 @@
 # software solely pursuant to the terms of the relevant commercial agreement.
 
 import sys
-from distutils.util import strtobool
 
 import colorama
 import shtab
@@ -130,6 +129,7 @@ from croud.subscriptions.commands import (
 from croud.tools.spinner import HALO
 from croud.users.commands import users_delete, users_list
 from croud.users.roles.commands import roles_list
+from croud.util import asbool
 
 # Arguments common to all import-job create commands
 import_job_create_common_args = [
@@ -161,7 +161,7 @@ import_job_create_common_args = [
     ),
     Argument(
         "--create-table",
-        type=lambda x: bool(strtobool(str(x))),  # noqa
+        type=lambda x: asbool(x),  # noqa
         required=False,
         help="Whether the table should be created automatically"
         " if it does not exist. If true new columns will also be added when the data"
@@ -592,7 +592,7 @@ command_tree = {
                         help="The CrateDB cluster ID to use.",
                     ),
                     Argument(
-                        "--value", type=lambda x: bool(strtobool(str(x))),
+                        "--value", type=lambda x: asbool(x),
                         required=True, help="The deletion protection status",
                     ),
                 ],
@@ -636,7 +636,7 @@ command_tree = {
                         help="The CrateDB cluster ID to use.",
                     ),
                     Argument(
-                        "--value", type=lambda x: bool(strtobool(str(x))),
+                        "--value", type=lambda x: asbool(x),
                         required=True, help="The suspended status.",
                     ),
                 ],
@@ -891,7 +891,7 @@ command_tree = {
                                      "return the files."
                             ),
                             Argument(
-                                "--summary", type=lambda x: bool(strtobool(str(x))),
+                                "--summary", type=lambda x: asbool(x),
                                 required=False,
                                 help="Show only global progress."
                             ),

--- a/croud/util.py
+++ b/croud/util.py
@@ -24,7 +24,7 @@ import subprocess
 import webbrowser
 from argparse import Namespace
 from datetime import datetime, timezone
-from typing import Tuple
+from typing import Any, Tuple
 
 from croud.api import Client
 from croud.config import CONFIG
@@ -156,3 +156,25 @@ def _set_gc_jwt(cmd_args: Namespace) -> None:
     CONFIG.set_current_gc_jwt_token(data.get("token"))  # type: ignore
     CONFIG.set_current_gc_cluster_id(cmd_args.cluster_id)  # type: ignore
     CONFIG.set_current_gc_jwt_token_expiry(data.get("expiry"))  # type: ignore
+
+
+def strtobool(val: str) -> int:
+    """Convert a string representation of truth to true (1) or false (0).
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+
+    Copied from `distutils.util.strtobool` (Python 3.11).
+    """
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return 1
+    elif val in ("n", "no", "f", "false", "off", "0"):
+        return 0
+    else:
+        raise ValueError("invalid truth value %r" % (val,))
+
+
+def asbool(val: Any) -> bool:
+    return bool(strtobool(str(val)))

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         "bitmath==1.3.3.1",
         "certifi",
         "colorama==0.4.6",
+        "importlib-metadata; python_version < '3.8'",
         "marshmallow==3.22.0",
         "pyyaml==6.0.2",
         "requests==2.32.3",
@@ -60,8 +61,11 @@ setup(
     ],
     extras_require={
         "testing": [
-            "tox==3.14.2",
-            "pytest-freezegun==0.4.2",
+            "pytest<9",
+            "pytest-cov<7",
+            "pytest-freezer<0.5",
+            "pytest-random-order<2",
+            "tox<4",
         ],
         "development": [
             "black==24.8.0",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,0 @@
-pytest==8.3.3
-pytest-random-order==1.1.1
-pytest-freezegun==0.4.2

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,6 @@
 envlist = py38,py39,py310,py311
 
 [testenv]
-deps = -r{toxinidir}/test-requirements.txt
+deps = -e{toxinidir}[testing]
 commands = pytest {posargs}
 setenv = LANG=en_US.UTF-8


### PR DESCRIPTION
## About
A few adjustments to prepare unlocking Python 3.12 and eventually 3.13.
The patch mainly phases out use of `pkg_resources` and `distutils.util`.
