### PR TITLE
CI: Add support for Python 3.12 and 3.13

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
       - name: Build docs
         run: |
           cd docs && make check

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,9 @@
 name: docs
 on:
-  pull_request: ~
   push:
     branches:
       - master
+  pull_request:
 
 concurrency:
   cancel-in-progress: true
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Build docs
         run: |
           cd docs && make check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
 
 concurrency:
   cancel-in-progress: true
@@ -19,7 +17,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - '3.11'
+        - '3.12'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -49,12 +47,14 @@ jobs:
     name: Tests with Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version:
         - '3.8'
         - '3.9'
         - '3.10'
         - '3.11'
+        - '3.12'
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - '3.12'
+        - '3.13'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -55,6 +55,7 @@ jobs:
         - '3.10'
         - '3.11'
         - '3.12'
+        - '3.13'
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,13 +12,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
-      - name: Install setuptools and wheel
+          python-version: '3.12'
+      - name: Install "build" package
         run: |
-          python -m pip install --upgrade pip setuptools wheel packaging
+          python -m pip install build
       - name: Build sdist and wheel
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@v1.1.0
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.12'
+          python-version: '3.13'
       - name: Install "build" package
         run: |
           python -m pip install build

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.11"
+    python: "3.12"
 
 sphinx:
   builder: html

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changes for croud
 Unreleased
 ==========
 
+- Added support for Python 3.12
+
 1.12.0 - 2024/08/30
 ===================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changes for croud
 Unreleased
 ==========
 
-- Added support for Python 3.12
+- Added support for Python 3.12 and 3.13
 
 1.12.0 - 2024/08/30
 ===================

--- a/setup.py
+++ b/setup.py
@@ -88,5 +88,6 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -87,5 +87,6 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,py311
+envlist = py38,py39,py310,py311,py312
 
 [testenv]
 deps = -e{toxinidir}[testing]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,py311,py312
+envlist = py38,py39,py310,py311,py312,py313
 
 [testenv]
 deps = -e{toxinidir}[testing]


### PR DESCRIPTION
## About
In `tests.util.fake_cloud.FakeCrateDBCloudServer`, `ssl.wrap_socket()` is no longer supported.

## Stacking
That other PR needs to be merged first.
- GH-543