### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - '3.8'
         - '3.9'
         - '3.10'
         - '3.11'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changes for croud
 Unreleased
 ==========
 
+- Dropped support for Python 3.8.
+
 1.13.0 - 2025/01/07
 ===================
 

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -10,7 +10,7 @@ Setup
 Pip
 ---
 
-Python >= 3.6 is required. Run ``croud`` within a virtual python environment::
+Python >= 3.9 is required. Run ``croud`` within a virtual python environment::
 
     python -m venv env
     source env/bin/activate
@@ -32,7 +32,7 @@ Alternatively, you can clone this repository, install it into a virtualenv and
 add the executable to your PATH environment variable::
 
     git clone git@github.com:crate/croud.git && cd croud/
-    python3.6 -m venv env
+    python3.12 -m venv env
     env/bin/pip install -e .
     export PATH=$PATH:$(pwd)/env/bin/croud
 
@@ -52,9 +52,9 @@ versions run::
     tox
 
 Alongside ``--`` it's possible to pass ``pytest`` args e.g. to run only a
-fraction of tests with python3.6::
+fraction of tests with python3.12::
 
-    tox -e py36 -- -k test_rest
+    tox -e py312 -- -k test_rest
 
 The test setup uses `pytest-random-order`_ to ensure better test separation.
 By default, the order will be random on the Python module level. That means,
@@ -64,12 +64,12 @@ When running tests using ``tox`` or ``py.test``, `pytest-random-order`_ will
 emit a seed value at the beginning which can be used to rerun tests with the
 specific order::
 
-    $ tox -e py37
+    $ tox -e py312
     ...
-    py37 run-test-pre: PYTHONHASHSEED='2789788418'
-    py37 run-test: commands[0] | pytest
+    py312 run-test-pre: PYTHONHASHSEED='2789788418'
+    py312 run-test: commands[0] | pytest
     ======================== test session starts =========================
-    platform linux -- Python 3.7.3, pytest-3.10.1, py-1.8.0, pluggy-0.12.0
+    platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
     Using --random-order-bucket=module
     Using --random-order-seed=240261
     ...
@@ -77,7 +77,7 @@ specific order::
 One can rerun a random test setup by passing ``--random-order-seed=<seed>`` to
 py.test::
 
-    $ tox -e py37 -- --random-order-seed=240261
+    $ tox -e py312 -- --random-order-seed=240261
 
 
 Debugging API calls
@@ -160,7 +160,7 @@ The documentation is written using `Sphinx`_ and `ReStructuredText`_.
 Working on the documentation
 ----------------------------
 
-Python 3.7 is required.
+Python 3.9 or higher is required.
 
 Change into the ``docs`` directory:
 

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
             "mypy<1.15",
         ],
     },
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
@@ -82,8 +82,6 @@ setup(
         "Operating System :: OS Independent",
         "Topic :: Database",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,py311,py312,py313
+envlist = py39,py310,py311,py312,py313
 
 [testenv]
 deps = -e{toxinidir}[testing]


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Python 3.8 reached EOL. and it is causing dependency upgrades to fail GH-546, GH-551

## Checklist

 - [ ] Link to issue this PR refers to (if applicable): Fixes #???
