### PR TITLE
Chore: Fix `exit` vs. `sys.exit`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 
 - Dropped support for Python 3.8.
 - Client: Accounted for edge-case when login token is an empty string
+- Fixed ``exit()`` vs. ``sys.exit()`` invocations to improve library use
 
 1.13.0 - 2025/01/07
 ===================

--- a/croud/api.py
+++ b/croud/api.py
@@ -19,6 +19,7 @@
 
 import enum
 import os
+import sys
 from argparse import Namespace
 from platform import python_version
 from typing import Any, Callable, Dict, Optional, Tuple, cast
@@ -170,7 +171,7 @@ class Client:
                 print_info("Use `croud login` to login to CrateDB Cloud.")
             else:
                 print_error("Oops. Something unexpected happened.")
-            exit(1)
+            sys.exit(1)
 
         # Refresh a previously provided token because it has timed out
         response_token = response.cookies.get("session")

--- a/croud/config/configuration.py
+++ b/croud/config/configuration.py
@@ -140,7 +140,6 @@ class Configuration:
             raise InvalidConfiguration(
                 f"{self._file_path} is not a valid configuration."
             ) from None
-            exit(1)
 
     def is_valid(self):
         try:

--- a/croud/login.py
+++ b/croud/login.py
@@ -16,7 +16,7 @@
 # However, if you have executed another commercial license agreement
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
-
+import sys
 from argparse import Namespace
 from typing import Optional
 
@@ -47,7 +47,7 @@ def login(args: Namespace) -> None:
 
     if not can_launch_browser():
         print_error("Login only works with a valid browser installed.")
-        exit(1)
+        sys.exit(1)
 
     if CONFIG.key and CONFIG.secret:
         print_warning(

--- a/croud/organizations/commands.py
+++ b/croud/organizations/commands.py
@@ -17,6 +17,7 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 import os
+import sys
 from argparse import Namespace
 from typing import Any, Tuple
 
@@ -59,7 +60,7 @@ def organizations_edit(args: Namespace) -> None:
         body["name"] = args.name
     if not body:
         print_error("No input arguments found.")
-        exit(1)
+        sys.exit(1)
 
     data, errors = client.put(f"/api/v2/organizations/{args.org_id}/", body=body)
     print_response(
@@ -321,7 +322,7 @@ def org_credits_edit(args: Namespace) -> None:
         payload["comment"] = args.comment
     if not payload:
         print_error("No input arguments found.")
-        exit(1)
+        sys.exit(1)
 
     data, errors = client.patch(
         f"/api/v2/organizations/{args.org_id}/credits/{args.credit_id}/", body=payload

--- a/croud/printer.py
+++ b/croud/printer.py
@@ -44,7 +44,7 @@ def print_format(
         Printer = PRINTERS[format]
     except KeyError:
         print_error("This print method is not supported.")
-        exit(1)
+        sys.exit(1)
     printer = Printer(keys, transforms)
     printer.print_rows(rows)
 

--- a/croud/projects/commands.py
+++ b/croud/projects/commands.py
@@ -16,7 +16,7 @@
 # However, if you have executed another commercial license agreement
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
-
+import sys
 from argparse import Namespace
 
 from croud.api import Client
@@ -62,7 +62,7 @@ def project_edit(args: Namespace) -> None:
         body["name"] = args.name
     if not body:
         print_error("No input arguments found.")
-        exit(1)
+        sys.exit(1)
 
     data, errors = client.patch(f"/api/v2/projects/{args.project_id}/", body=body)
     print_response(

--- a/croud/util.py
+++ b/croud/util.py
@@ -21,6 +21,7 @@ import functools
 import os
 import platform
 import subprocess
+import sys
 import webbrowser
 from argparse import Namespace
 from datetime import datetime, timezone
@@ -118,12 +119,12 @@ def org_id_config_fallback(cmd):  # decorator
     def _wrapper(cmd_args: Namespace):  # decorator logic
         if cmd_args.sudo and not cmd_args.org_id:
             print_error("An organization ID is required. Please pass --org-id.")
-            exit(1)
+            sys.exit(1)
 
         cmd_args.org_id = cmd_args.org_id or CONFIG.organization
         if not cmd_args.org_id:
             print_error("An organization ID is required. Please pass --org-id.")
-            exit(1)
+            sys.exit(1)
 
         cmd(cmd_args)
 


### PR DESCRIPTION
## About
A few more refinements while working on headless mode support.

## Details
> `exit` is a helper for the interactive shell - `sys.exit` is intended for use in programs.
>
> -- https://stackoverflow.com/q/6501121

## References
- https://github.com/crate/cratedb-toolkit/pull/81
- GH-562
