### PR TITLE
Fix duplicate JSON output in `croud clusters deploy`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Unreleased
 - Dropped support for Python 3.8.
 - Client: Accounted for edge-case when login token is an empty string
 - Fixed ``exit()`` vs. ``sys.exit()`` invocations to improve library use
+- Fixed duplicate JSON output in ``croud clusters deploy``
 
 1.13.0 - 2025/01/07
 ===================

--- a/croud/clusters/commands.py
+++ b/croud/clusters/commands.py
@@ -114,14 +114,13 @@ def clusters_deploy(args: Namespace) -> None:
         return
 
     data, errors = client.post(f"/api/v2/organizations/{org_id}/clusters/", body=body)
-    print_response(
-        data=data,
-        errors=errors,
-        keys=["id", "name", "fqdn", "url"],
-        output_fmt=get_output_format(args),
-    )
-
     if errors or not data:
+        print_response(
+            data=data,
+            errors=errors,
+            keys=["id", "name", "fqdn", "url"],
+            output_fmt=get_output_format(args),
+        )
         return
 
     print_info("Cluster creation initiated. It may take a few minutes to complete.")

--- a/docs/commands/clusters.rst
+++ b/docs/commands/clusters.rst
@@ -74,11 +74,6 @@ Example
        --username admin \
        --password "8Hed#kd$8^9i4Q#65fT4GKQI" \
        --subscription-id 782dfc00-7b25-4f48-8381-b1b096dd1619
-   +--------------------------------------+------------------------+----------+--------------+--------------------------------------+-------------+--------------------------------------------------+
-   | id                                   | name                   | numNodes | crateVersion | projectId                            | username    | fqdn                                             |
-   |--------------------------------------+------------------------+----------+--------------+--------------------------------------+-------------+--------------------------------------------------|
-   | 8d6a7c3c-61d5-11e9-a639-34e12d2331a1 | my-first-crate-cluster |        1 | 5.3.2        | 952cd102-91c1-4837-962a-12ecb71a6ba8 | admin       | my-first-crate-cluster.eastus.azure.cratedb.net. |
-   +--------------------------------------+------------------------+----------+--------------+--------------------------------------+-------------+--------------------------------------------------+
    ==> Info: Cluster creation initiated. It may take a few minutes to complete.
    ==> Info: Status: REGISTERED (Your creation request was received and is pending processing.)
    ==> Info: Status: IN_PROGRESS (Cluster creation started. Waiting for the node(s) to be created and creating other required resources.)
@@ -86,7 +81,7 @@ Example
    +--------------------------------------+------------------------+----------+--------------+--------------------------------------+-------------+--------------------------------------------------+
    | id                                   | name                   | numNodes | crateVersion | projectId                            | username    | fqdn                                             |
    |--------------------------------------+------------------------+----------+--------------+--------------------------------------+-------------+--------------------------------------------------|
-   | 8d6a7c3c-61d5-11e9-a639-34e12d2331a1 | my-first-crate-cluster |        1 | 4.8.0        | 952cd102-91c1-4837-962a-12ecb71a6ba8 | admin       | my-first-crate-cluster.eastus.azure.cratedb.net. |
+   | 8d6a7c3c-61d5-11e9-a639-34e12d2331a1 | my-first-crate-cluster |        1 | 5.3.2        | 952cd102-91c1-4837-962a-12ecb71a6ba8 | admin       | my-first-crate-cluster.eastus.azure.cratedb.net. |
    +--------------------------------------+------------------------+----------+--------------+--------------------------------------+-------------+--------------------------------------------------+
 
 Deployment of testing/nightly versions


### PR DESCRIPTION
## Problem
`croud clusters deploy` yielded duplicate output, which is detrimental when using `--output-fmt=json`, because the output can not be parsed by downstream programs.

## References
- https://github.com/crate/cratedb-toolkit/pull/81#pullrequestreview-1737914416