### PR TITLE
Remove page local toc

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -12,11 +12,6 @@ would be the following path::
 To determine the location of the config files ``croud`` uses the `appdirs`_
 package. Please refer to package documentation for further details.
 
-.. rubric:: Table of Contents
-
-.. contents::
-   :local:
-
 Configuration file formatting
 =============================
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -4,15 +4,10 @@
 Getting Started
 ===============
 
-Croud CLI is available as a `pip`_ package.
-
-.. rubric:: Table of Contents
-
-.. contents::
-   :local:
-
 Installation
 ============
+
+Croud CLI is available as a `pip`_ package.
 
 To install, run:
 

--- a/docs/user-roles.rst
+++ b/docs/user-roles.rst
@@ -12,11 +12,6 @@ the purposes of the Croud CLI.
    The ``users roles list`` command provides a list of fully qualified role
    names.
 
-.. rubric:: Table of Contents
-
-.. contents::
-   :local:
-
 .. _organization-roles:
 
 Organization roles


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Page local TOC are now redundant with the right hand side TOC.

