### PR TITLE
Dependencies: Migrate from `appdirs` to `platformdirs`

### DIFF
--- a/croud/config/configuration.py
+++ b/croud/config/configuration.py
@@ -21,8 +21,8 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 import yaml
-from appdirs import user_config_dir
 from marshmallow import ValidationError
+from platformdirs import user_config_dir
 
 from croud.config.exceptions import InvalidConfiguration, InvalidProfile
 from croud.config.schemas import ConfigSchema, ProfileSchema

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -9,7 +9,7 @@ would be the following path::
 
    $HOME/.config/Crate/croud.yaml
 
-To determine the location of the config files ``croud`` uses the `appdirs`_
+To determine the location of the config files ``croud`` uses the `platformdirs`_
 package. Please refer to package documentation for further details.
 
 Configuration file formatting
@@ -113,6 +113,6 @@ You can either delete the old configuration file, or manually edit the content
 by pasting the default configuration stated above.
 
 
-.. _appdirs: https://pypi.org/project/appdirs/
+.. _platformdirs: https://pypi.org/project/platformdirs/
 .. _CrateDB Cloud API keys: https://cratedb.com/docs/cloud/en/latest/organization/api.html
 .. _YAML: https://yaml.org

--- a/setup.py
+++ b/setup.py
@@ -45,12 +45,12 @@ setup(
     entry_points={"console_scripts": ["croud = croud.__main__:main"]},
     packages=find_packages(),
     install_requires=[
-        "appdirs>=1,<2",
         "bitmath>=1,<2",
         "certifi",
         "colorama>=0.3,<1",
         "importlib-metadata; python_version < '3.8'",
         "marshmallow>=3,<4",
+        "platformdirs>=4,<5",
         "pyyaml>=6.0.2,<7",
         "requests>=2,<3",
         "tabulate>=0.8,<1.0",


### PR DESCRIPTION
## About
`platformdirs` is the canonical successor to `appdirs`. Within the scope of croud, no breaking changes are expected.

## Details
We've exercised a little side-by-side comparison on macOS.
```python
>>> import appdirs
>>> appdirs.user_config_dir("Crate")
'/Users/amo/Library/Application Support/Crate'

>>> import platformdirs
>>> platformdirs.user_config_dir("Crate")
'/Users/amo/Library/Application Support/Crate'
```
