### PR TITLE
CI: Stop building `docs` on `macos-latest`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ on:
 # Cancel in-progress jobs when pushing to the same branch.
 concurrency:
   cancel-in-progress: true
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
 
 jobs:
   documentation:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   cancel-in-progress: true
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
 
 jobs:
   lint:


### PR DESCRIPTION
## About
It saves a few cycles on the linkchecker, both on GHA and on remote web servers.

## References
- https://github.com/crate/crash/pull/470
- https://github.com/crate/crash/issues/469