### PR TITLE
Prepare release 1.14.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for croud
 Unreleased
 ==========
 
+1.14.0 - 2025/06/12
+===================
+
 - Dropped support for Python 3.8.
 - Client: Accounted for edge-case when login token is an empty string
 - Fixed ``exit()`` vs. ``sys.exit()`` invocations to improve library use

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@
 from packaging.version import Version
 from setuptools import find_packages, setup
 
-__version__ = Version("1.13.0")
+__version__ = Version("1.14.0")
 
 try:
     with open("README.rst", "r", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
- Dropped support for Python 3.8.
- Client: Accounted for edge-case when login token is an empty string
- Fixed `exit()` vs. `sys.exit()` invocations to improve library use
- Fixed duplicate JSON output in croud clusters deploy
- Headless mode: Started accepting environment variables `CRATEDB_CLOUD_API_KEY` and `CRATEDB_CLOUD_API_SECRET` to authenticate with API keys when no `croud.yaml` configuration file exists.
- Dependencies: Relaxed version pinning to make package compatible with others
- Dependencies: Migrated from ``appdirs`` to ``platformdirs``
