### PR TITLE
Updated release GitHub action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
         run: |
           python -m build
       - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.1.0
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
- Fixed the Github action using an outdated dependency that lead it to fail.
- Note the project was released by manually creating the 1.14.0 tag from this branch, to avoid polluting main in case the fix didn't work.
