### PR TITLE
Add subcommand to update a cluster's subscription

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,17 +5,26 @@ Changes for croud
 Unreleased
 ==========
 
+- Added new resource ``clusters subscription`` and subcommand that allows
+  users to transfer clusters between subscriptions.
+
 1.14.0 - 2025/06/12
 ===================
 
 - Dropped support for Python 3.8.
+
 - Client: Accounted for edge-case when login token is an empty string
+
 - Fixed ``exit()`` vs. ``sys.exit()`` invocations to improve library use
+
 - Fixed duplicate JSON output in ``croud clusters deploy``
+
 - Headless mode: Started accepting environment variables ``CRATEDB_CLOUD_API_KEY``
   and ``CRATEDB_CLOUD_API_SECRET`` to authenticate with API keys when no ``croud.yaml``
   configuration file exists.
+
 - Dependencies: Relaxed version pinning to make package compatible with others
+
 - Dependencies: Migrated from ``appdirs`` to ``platformdirs``
 
 1.13.0 - 2025/01/07

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -50,6 +50,7 @@ from croud.clusters.commands import (
     clusters_set_suspended,
     clusters_snapshots_list,
     clusters_snapshots_restore,
+    clusters_subscription_update,
     clusters_upgrade,
     create_scheduled_job,
     delete_scheduled_job,
@@ -735,6 +736,30 @@ command_tree = {
                             ),
                         ],
                         "resolver": clusters_snapshots_restore,
+                    },
+                },
+            },
+            "subscription": {
+                "help": "Manage subscription of a CrateDB cluster.",
+                "commands": {
+                    "update": {
+                        "help": "Transfer a CrateDB cluster between subscriptions.",
+                        "extra_args": [
+                            Argument(
+                                "--cluster-id", type=str, required=True,
+                                help="The CrateDB cluster ID to use.",
+                            ),
+                            Argument(
+                                "--old-subscription-id", type=str, required=True,
+                                help="The current subscription ID.",
+                            ),
+                            Argument(
+                                "--new-subscription-id", type=str, required=True,
+                                help="The ID of the subscription the cluster should be "
+                                     "transferred to.",
+                            ),
+                        ],
+                        "resolver": clusters_subscription_update,
                     },
                 },
             },

--- a/croud/clusters/commands.py
+++ b/croud/clusters/commands.py
@@ -730,6 +730,24 @@ def clusters_snapshots_restore(args: Namespace) -> None:
     )
 
 
+def clusters_subscription_update(args: Namespace) -> None:
+    body = {
+        "old_subscription_id": args.old_subscription_id,
+        "new_subscription_id": args.new_subscription_id,
+    }
+    client = Client.from_args(args)
+    data, errors = client.post(
+        f"/api/v2/clusters/{args.cluster_id}/transfer-subscription/", body=body
+    )
+    print_response(
+        data=data,
+        errors=errors,
+        keys=["id", "name", "subscription_id"],
+        success_message=("Cluster subscription_id successfully updated"),
+        output_fmt=get_output_format(args),
+    )
+
+
 def export_jobs_create(args: Namespace) -> None:
     body = {
         "source": {

--- a/docs/commands/index.rst
+++ b/docs/commands/index.rst
@@ -97,7 +97,7 @@ Region Support
 * If the ``--region`` flag is omitted, Croud defaults to the region specified in the current profile's API endpoint.
 
 .. code-block:: console
-    
+
     sh$ croud config profiles current
 
 * The special region ``_any_`` allows listing resources across all regions, regardless of where they were deployed.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -2,17 +2,17 @@
 Configuration
 =============
 
-Croud stores user-specific data (such as authentication tokens, profiles, and settings) in a configuration 
+Croud stores user-specific data (such as authentication tokens, profiles, and settings) in a configuration
 file on disk to persist across sessions.
 
 Config File Location
 ====================
 
-The configuration file is located inside your system's user-specific config directory. 
+The configuration file is located inside your system's user-specific config directory.
 On Linux, for example, the path is:
 
 .. code-block:: console
-   
+
    sh$ $HOME/.config/Crate/croud.yaml
 
 Croud uses the `platformdirs`_ Python package to determine the correct config directory for your operating system.
@@ -63,8 +63,8 @@ Top-Level Keys
 
 :``profiles``:
 
-    There is just one profile configured in the default configuration file. 
-    You would only need different profiles if you want to authenticate as 
+    There is just one profile configured in the default configuration file.
+    You would only need different profiles if you want to authenticate as
     different users or use different default organizations.
 
     Each profile includes the following settings:
@@ -83,7 +83,7 @@ Top-Level Keys
 
 .. TIP::
 
-   If both ``auth-token`` and ``key`` / ``secret`` are present, ``auth-token`` takes precedence. 
+   If both ``auth-token`` and ``key`` / ``secret`` are present, ``auth-token`` takes precedence.
    If you face unexpected authorization errors, try to force key-based auth, explicitly set ``auth-token: NULL``.
 
 
@@ -107,13 +107,13 @@ If no ``croud.yaml`` configuration file exists, the program also accepts the
 ``CRATEDB_CLOUD_API_KEY`` and ``CRATEDB_CLOUD_API_SECRET`` environment variables
 to support headless authentication per `CrateDB Cloud API keys`_.
 
-In environments where no ``croud.yaml`` exists (e.g., CI pipelines), 
+In environments where no ``croud.yaml`` exists (e.g., CI pipelines),
 you can authenticate using environment variables:
 
 .. code-block:: console
 
     sh$ export CRATEDB_CLOUD_API_KEY=your-api-key
-    sh$ export CRATEDB_CLOUD_API_SECRET=your-secret 
+    sh$ export CRATEDB_CLOUD_API_SECRET=your-secret
 
 Check `CrateDB Cloud API keys`_ for the instructions on how to generate a key and secret.
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -41,7 +41,7 @@ This will open a browser window to authenticate with your CrateDB Cloud account.
 .. TIP::
 
     For headless environments (e.g., CI/CD pipelines), you can authenticate by setting the following environment variables instead of running ``croud login``:
-    
+
     * ``CRATEDB_CLOUD_API_KEY``
 
     * ``CRATEDB_CLOUD_API_SECRET``

--- a/docs/user-roles.rst
+++ b/docs/user-roles.rst
@@ -4,16 +4,16 @@
 User Roles
 ==========
 
-This page provides an overview of the user roles available in `CrateDB Cloud`_, 
+This page provides an overview of the user roles available in `CrateDB Cloud`_,
 specifically in the context of using the Croud CLI.
 
 .. tip::
 
    To view all available role names, run:
-   
+
    .. code-block:: console
-    
-    sh$ croud users roles list 
+
+    sh$ croud users roles list
 
 .. _organization-roles:
 

--- a/tests/commands/test_clusters.py
+++ b/tests/commands/test_clusters.py
@@ -2031,3 +2031,32 @@ def test_export_job_create(mock_client_request, mock_copy, save_file):
         mock_copy.assert_called_once()
     else:
         mock_copy.assert_not_called()
+
+
+@mock.patch.object(Client, "request", return_value=({}, None))
+def test_clusters_subscription_update(mock_request):
+    cluster_id = gen_uuid()
+    old_subscription_id = gen_uuid()
+    new_subscription_id = gen_uuid()
+
+    call_command(
+        "croud",
+        "clusters",
+        "subscription",
+        "update",
+        "--cluster-id",
+        cluster_id,
+        "--old-subscription-id",
+        old_subscription_id,
+        "--new-subscription-id",
+        new_subscription_id,
+    )
+    assert_rest(
+        mock_request,
+        RequestMethod.POST,
+        f"/api/v2/clusters/{cluster_id}/transfer-subscription/",
+        body={
+            "old_subscription_id": old_subscription_id,
+            "new_subscription_id": new_subscription_id,
+        },
+    )


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
This adds a new subscommand to transfer a CrateDB cluster between subscriptions.
```
croud clusters subscription update \
  --cluster-id <cluster_uuid> \
  --old-subscription-id <old_subscription_uuid> \
  --new-subscription-id <new_subscription_uuid>
```

## Checklist

 - [x] Link to issue this PR refers to (if applicable): https://github.com/crate/cloud/issues/2037
