### PR TITLE
Add --master-product-name option to clusters deploy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for croud
 Unreleased
 ==========
 
+- Added ``--master-product-name`` option to ``clusters deploy`` for attaching
+  dedicated master nodes (e.g. ``master_cr2``) to a cluster at deploy time.
+
 - Updated documentation.
 
 - Added support for DynamoDB data jobs.

--- a/croud/__main__.py
+++ b/croud/__main__.py
@@ -482,6 +482,13 @@ command_tree = {
                              "products available scale units.",
                     ),
                     Argument(
+                        "--master-product-name", type=str, required=False,
+                        help="Optional dedicated master-node product (e.g. "
+                             "'master_cr2'). Only valid for products that offer "
+                             "dedicated masters (CR3/CR4/CR5). Omit for a cluster "
+                             "without dedicated master nodes.",
+                    ),
+                    Argument(
                         "-p", "--project-id", type=str,
                         required=False,
                         help="The project ID to use. We recommend using the org-id "

--- a/croud/clusters/commands.py
+++ b/croud/clusters/commands.py
@@ -104,6 +104,8 @@ def clusters_deploy(args: Namespace) -> None:
 
     if args.unit:
         body["cluster"]["product_unit"] = args.unit
+    if args.master_product_name:
+        body["cluster"]["master_product_name"] = args.master_product_name
     _handle_edge_params(body["cluster"], args)
 
     client = Client.from_args(args)

--- a/docs/commands/clusters.rst
+++ b/docs/commands/clusters.rst
@@ -96,6 +96,11 @@ Example
    | 8d6a7c3c-61d5-11e9-a639-34e12d2331a1 | my-first-crate-cluster | my-first-crate-cluster.aks1.westeurope.azure.cratedb.net. | https://my-first-crate-cluster.aks1.westeurope.azure.cratedb.net:4200 |
    +--------------------------------------+------------------------+-----------------------------------------------------------+-----------------------------------------------------------------------+
 
+.. note::
+
+   To attach dedicated master nodes, add ``--master-product-name master_cr2``.
+   This is only valid for products that offer dedicated masters (CR3/CR4/CR5).
+
 Deployment of testing/nightly versions
 --------------------------------------
 

--- a/tests/commands/test_clusters.py
+++ b/tests/commands/test_clusters.py
@@ -69,6 +69,68 @@ def test_clusters_list_with_organization_id(mock_request):
     )
 
 
+@mock.patch.object(Client, "request", return_value=({}, None))
+@mock.patch("time.sleep")
+def test_clusters_deploy_with_master(_mock_sleep, mock_request):
+    project_id = gen_uuid()
+    cluster_id = gen_uuid()
+    subscription_id = gen_uuid()
+
+    def mock_call(*args, **kwargs):
+        if args[0] == RequestMethod.POST:
+            return {"id": cluster_id}, None
+        if args[0] == RequestMethod.GET and "/projects/" in args[1]:
+            return {"organization_id": "123"}, None
+        if args[0] == RequestMethod.GET and "/operations/" in args[1]:
+            return {"operations": [{"status": "SUCCEEDED"}]}, None
+        return None, None
+
+    mock_request.side_effect = mock_call
+    call_command(
+        "croud",
+        "clusters",
+        "deploy",
+        "--product-name",
+        "cr3",
+        "--tier",
+        "default",
+        "--master-product-name",
+        "master_cr2",
+        "--project-id",
+        project_id,
+        "--cluster-name",
+        "crate_cluster",
+        "--version",
+        "6.2.1",
+        "--username",
+        "foobar",
+        "--password",
+        "s3cr3t!s3cr3t!s3cr3t!s3cr3t!",
+        "--subscription-id",
+        subscription_id,
+    )
+    assert_rest(
+        mock_request,
+        RequestMethod.POST,
+        "/api/v2/organizations/123/clusters/",
+        body={
+            "cluster": {
+                "crate_version": "6.2.1",
+                "name": "crate_cluster",
+                "password": "s3cr3t!s3cr3t!s3cr3t!s3cr3t!",
+                "product_name": "cr3",
+                "product_tier": "default",
+                "master_product_name": "master_cr2",
+                "username": "foobar",
+                "channel": "stable",
+            },
+            "project_id": project_id,
+            "subscription_id": subscription_id,
+        },
+        any_times=True,
+    )
+
+
 @pytest.mark.parametrize("status", ["SUCCEEDED", "FAILED", None])
 @mock.patch.object(Client, "request", return_value=({}, None))
 @mock.patch("time.sleep")


### PR DESCRIPTION
## What

Adds an optional `--master-product-name` flag to `croud clusters deploy` so customers can attach **dedicated master nodes** to a data cluster (CR3/CR4/CR5) at deploy time.

## Why

Dedicated master nodes are an optional, deploy-time add-on. The customer picks a master product (e.g. `master_cr2` / `master_cr3`); node count (odd quorum, 3/5) and pricing are entirely server-driven. The only customer-facing wire change is the optional `cluster.master_product_name` field, which the cloud-api create endpoint **already accepts and validates** against the cluster product's `master_options`.

This keeps the CLI in parity with cloud-ui for the master-nodes feature. Tracks crate/cloud#2744.

## Changes

- `croud/__main__.py` — new optional `--master-product-name` argument on `clusters deploy`.
- `croud/clusters/commands.py` — adds `master_product_name` to the request body **only when set**, so masterless deploys send a byte-for-byte unchanged body.
- `tests/commands/test_clusters.py` — `test_clusters_deploy_with_master` asserts the field lands in the POST body; existing masterless tests cover the negative case.
- Docs + `CHANGES.rst` updated.

## Scope (intentionally minimal)

Deploy-time only. The following are **out of scope** because they depend on cloud-api surfaces not yet implemented, or don't exist in croud:

- No master node-count flag — count is product-driven (server-enforced odd quorum).
- No pricing math — masters reuse the base CRx rate server-side; croud has no price command.
- No `clusters scale` / `set-product` changes — no customer master-resize exists in v1.
- No `products list` master discovery — cloud-api does not yet expose `master_options` on `ProductSchema`.

### Follow-up cloud-api asks (tracked under crate/cloud#2744)

1. Dump `num_master_nodes` (+ optionally `hardware_specs_master`) in `ClusterSchema` → unblocks showing master count/specs on `clusters get`/`list`.
2. Add `master_options` to `ProductSchema` → unblocks master discovery in `products list`.

## Test plan

- `pytest tests/commands/test_clusters.py` → 73 passed.
- `pre-commit run` → black, flake8, isort, mypy all green.

LLM assisted: Claude Opus 4.8 (1M context)